### PR TITLE
Implement advanced Tana create endpoints

### DIFF
--- a/codex/tasks/tana_create.py
+++ b/codex/tasks/tana_create.py
@@ -6,26 +6,24 @@ import logging
 
 TANA_API_KEY = os.getenv("TANA_API_KEY")
 
-def run(context: dict):
-    content = context.get("content", "").strip()
 
+def run(context: dict):
     if not TANA_API_KEY:
         logging.error("[❌] TANA_API_KEY is missing")
         return
 
-    if not content:
-        logging.error("[❌] No content provided to send to Tana")
-        return
-
-    headers = {
-        "Authorization": f"Bearer {TANA_API_KEY}",
-        "Content-Type": "application/json"
-    }
+    name = context.get("content", "Untitled Node")
+    supertags = context.get("tags", [])
+    fields = context.get("fields", {})
+    children = context.get("children", [])
 
     payload = {
         "nodes": [
             {
-                "name": content
+                "name": name,
+                "supertags": supertags,
+                "fields": fields,
+                "children": [{"name": c} for c in children],
             }
         ]
     }
@@ -33,14 +31,16 @@ def run(context: dict):
     try:
         response = httpx.post(
             "https://europe-west1.api.tana.inc/create/nodes",
-            headers=headers,
+            headers={
+                "Authorization": f"Bearer {TANA_API_KEY}",
+                "Content-Type": "application/json",
+            },
             json=payload,
-            timeout=10
+            timeout=10,
         )
         response.raise_for_status()
-        logging.info("[✅] Node created in Tana successfully")
-        logging.info(f"↳ Response: {response.json()}")
-
+        logging.info(f"[✅] Node created in Tana: {name}")
+        logging.debug(f"[🔁] Response: {response.json()}")
     except httpx.HTTPError as e:
-        logging.error(f"[❌] Tana API request failed: {str(e)}")
+        logging.error(f"[❌] Tana API error: {str(e)}")
 


### PR DESCRIPTION
## Summary
- expand `tana_create` task to build full payloads including tags, fields and children
- update API server to accept full Tana node data and add assistant webhook

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d86bf26c8323981bc4db475b82da