### PR TITLE
Add AI prompt tasks and chaining

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # API Keys for AI services
-OPENAI_API_KEY=<your OpenAI API key>
+OPENAI_API_KEY=sk-xxx
 CLAUDE_API_KEY=<your Anthropic API key>
+GEMINI_API_KEY=your-gemini-key
 
 # Deployment tokens
 VERCEL_TOKEN=<your Vercel deployment token>
-SUPABASE_SERVICE_KEY=<your Supabase service key>
+SUPABASE_SERVICE_KEY=your-key
 STRIPE_SECRET_KEY=<your Stripe secret key>
 
 # Make.com webhook security (optional)

--- a/codex/tasks/__init__.py
+++ b/codex/tasks/__init__.py
@@ -8,4 +8,7 @@ from . import (
     backup_site,
     refresh_content,
     tana_create,
+    claude_prompt,
+    gemini_prompt,
+    multi_task,
 )

--- a/codex/tasks/claude_prompt.py
+++ b/codex/tasks/claude_prompt.py
@@ -1,0 +1,61 @@
+"""Send a prompt to Anthropic Claude and return the completion."""
+
+import os
+import httpx
+import logging
+from datetime import datetime
+from pathlib import Path
+from utils.text_helpers import clean_ai_response
+
+TASK_ID = "claude_prompt"
+TASK_DESCRIPTION = "Send a prompt to Claude and return response"
+REQUIRED_FIELDS = ["prompt"]
+
+logger = logging.getLogger(__name__)
+
+CLAUDE_API_KEY = os.getenv("OPENAI_API_KEY") or os.getenv("CLAUDE_API_KEY")
+API_URL = "https://api.anthropic.com/v1/messages"
+
+
+def _append_log(prompt: str, completion: str) -> None:
+    """Append raw Claude interaction to dated log file."""
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+    fname = log_dir / f"claude_{datetime.utcnow().date()}.txt"
+    with fname.open("a", encoding="utf-8") as f:
+        f.write(f"[{datetime.utcnow().isoformat()}]\nPrompt: {prompt}\nResponse: {completion}\n\n")
+
+
+def run(context: dict) -> dict:
+    """Execute a Claude API call."""
+    prompt = context.get("prompt", "")
+    model = context.get("model", "claude-3-opus")
+    temperature = context.get("temperature", 0.7)
+
+    if not CLAUDE_API_KEY:
+        logger.error("Missing Claude API key. Set OPENAI_API_KEY or CLAUDE_API_KEY")
+        return {"error": "missing_api_key"}
+
+    payload = {
+        "model": model,
+        "max_tokens": 1024,
+        "temperature": temperature,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    headers = {
+        "x-api-key": CLAUDE_API_KEY,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+
+    try:
+        response = httpx.post(API_URL, json=payload, headers=headers, timeout=30)
+        response.raise_for_status()
+        completion_raw = response.json().get("content", [{}])[0].get("text", "")
+        completion = clean_ai_response(completion_raw)
+        _append_log(prompt, completion)
+        logger.info("Claude completion length %s", len(completion))
+        return {"completion": completion}
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Claude API call failed: %s", exc)
+        return {"error": str(exc)}

--- a/codex/tasks/gemini_prompt.py
+++ b/codex/tasks/gemini_prompt.py
@@ -1,0 +1,54 @@
+"""Send a prompt to Google Gemini and return the completion."""
+
+import os
+import httpx
+import logging
+from datetime import datetime
+from pathlib import Path
+from utils.text_helpers import clean_ai_response
+
+TASK_ID = "gemini_prompt"
+TASK_DESCRIPTION = "Send a prompt to Gemini and return response"
+REQUIRED_FIELDS = ["prompt"]
+
+logger = logging.getLogger(__name__)
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+API_URL_TEMPLATE = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+
+def _append_log(prompt: str, completion: str) -> None:
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+    fname = log_dir / f"gemini_{datetime.utcnow().date()}.txt"
+    with fname.open("a", encoding="utf-8") as f:
+        f.write(f"[{datetime.utcnow().isoformat()}]\nPrompt: {prompt}\nResponse: {completion}\n\n")
+
+
+def run(context: dict) -> dict:
+    prompt = context.get("prompt", "")
+    model = context.get("model", "gemini-1.5-pro")
+
+    if not GEMINI_API_KEY:
+        logger.error("Missing GEMINI_API_KEY env var")
+        return {"error": "missing_api_key"}
+
+    payload = {"contents": [{"parts": [{"text": prompt}]}]}
+    url = f"{API_URL_TEMPLATE.format(model=model)}?key={GEMINI_API_KEY}"
+    try:
+        response = httpx.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        completion_raw = (
+            data.get("candidates", [{}])[0]
+            .get("content", {})
+            .get("parts", [{}])[0]
+            .get("text", "")
+        )
+        completion = clean_ai_response(completion_raw)
+        _append_log(prompt, completion)
+        logger.info("Gemini completion length %s", len(completion))
+        return {"completion": completion}
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Gemini API call failed: %s", exc)
+        return {"error": str(exc)}

--- a/codex/tasks/multi_task.py
+++ b/codex/tasks/multi_task.py
@@ -1,0 +1,46 @@
+"""Run a chain of tasks sequentially."""
+
+import logging
+from typing import Any, Dict, List
+
+from codex.brainops_operator import run_task
+
+TASK_ID = "multi_task"
+TASK_DESCRIPTION = "Run a chain of tasks in order"
+REQUIRED_FIELDS = ["tasks"]
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_context(ctx: Dict[str, Any], results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    ctx = ctx.copy()
+    if "content_from" in ctx:
+        idx = ctx.pop("content_from")
+        if 0 <= idx < len(results):
+            prev = results[idx]
+            value = (
+                prev.get("completion")
+                or prev.get("result")
+                or str(prev)
+            )
+            ctx["content"] = value
+    if "output_from" in ctx:
+        idx = ctx.pop("output_from")
+        if 0 <= idx < len(results):
+            ctx["output"] = results[idx]
+    return ctx
+
+
+def run(context: Dict[str, Any]) -> Dict[str, Any]:
+    tasks = context.get("tasks") or []
+    if not isinstance(tasks, list) or not tasks:
+        return {"error": "tasks must be a non-empty list"}
+
+    results: List[Any] = []
+    for task_def in tasks:
+        task_id = task_def.get("task")
+        task_ctx = task_def.get("context", {})
+        task_ctx = _resolve_context(task_ctx, results)
+        result = run_task(task_id, task_ctx)
+        results.append(result)
+    return {"results": results}

--- a/utils/text_helpers.py
+++ b/utils/text_helpers.py
@@ -1,0 +1,13 @@
+"""Utility helpers for AI text manipulation."""
+
+
+def clean_ai_response(text: str) -> str:
+    """Trim whitespace from AI responses."""
+    return text.strip()
+
+
+def truncate(text: str, max_length: int = 2000) -> str:
+    """Truncate text for logging or previews."""
+    if len(text) > max_length:
+        return text[:max_length] + "..."
+    return text


### PR DESCRIPTION
## Summary
- add Claude and Gemini prompt tasks with logging
- implement multi-task chaining
- expose new tasks via package init
- add utility helpers for AI text
- document new environment keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e83daf30832395db442b866eed03