### PR TITLE
Implement encrypted secrets vault

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ OPENAI_API_KEY=sk-xxx
 CLAUDE_API_KEY=<your Anthropic API key>
 GEMINI_API_KEY=your-gemini-key
 
+# Encryption key for secrets
+FERNET_SECRET=your-fernet-key
+
 # Deployment tokens
 VERCEL_TOKEN=<your Vercel deployment token>
 SUPABASE_SERVICE_KEY=your-key

--- a/README.md
+++ b/README.md
@@ -25,4 +25,12 @@ Copy `.env.example` to `.env` and fill in the required keys.
 ## Tasks
 Tasks live in `codex/tasks/` and each implements a `run(context)` function returning structured results.
 
+### Secrets Vault
+
+The API exposes endpoints under `/secrets` for storing and retrieving encrypted credentials. Example:
+
+```bash
+curl -X POST http://localhost:10000/secrets/store -H "Content-Type: application/json" -d '{"name":"CLAUDE_API_KEY","value":"sk-xyz"}'
+```
+
 You can view available tasks by calling the `/docs/registry` endpoint once the server is running.

--- a/codex/tasks/__init__.py
+++ b/codex/tasks/__init__.py
@@ -13,4 +13,5 @@ from . import (
     multi_task,
     rag_query,
     claude_summarize,
+    secrets,
 )

--- a/codex/tasks/secrets.py
+++ b/codex/tasks/secrets.py
@@ -1,0 +1,97 @@
+"""Manage encrypted secrets stored in Supabase."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import json
+from pathlib import Path
+
+from utils.crypto import encrypt, decrypt
+from supabase_client import supabase
+
+
+TASK_ID = "secrets"
+TASK_DESCRIPTION = "Store, retrieve and delete encrypted secrets"
+REQUIRED_FIELDS: list[str] = []
+
+_AUDIT_FILE = Path("logs/secrets_audit.json")
+
+
+def _log_audit(name: str, action: str) -> None:
+    _AUDIT_FILE.parent.mkdir(exist_ok=True)
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "name": name,
+        "action": action,
+    }
+    history: list[dict] = []
+    if _AUDIT_FILE.exists():
+        try:
+            history = json.loads(_AUDIT_FILE.read_text())
+        except Exception:  # noqa: BLE001
+            history = []
+    history.append(entry)
+    _AUDIT_FILE.write_text(json.dumps(history[-200:], indent=2))
+
+
+def store_secret(name: str, value: str) -> None:
+    encrypted = encrypt(value)
+    supabase.table("secrets").insert({"name": name, "value": encrypted}).execute()
+    _log_audit(name, "store")
+
+
+def retrieve_secret(name: str) -> str | None:
+    row = (
+        supabase.table("secrets")
+        .select("*")
+        .eq("name", name)
+        .limit(1)
+        .execute()
+    )
+    if row.data:
+        value = decrypt(row.data[0]["value"])
+        _log_audit(name, "retrieve")
+        return value
+    return None
+
+
+def delete_secret(name: str) -> None:
+    supabase.table("secrets").delete().eq("name", name).execute()
+    _log_audit(name, "delete")
+
+
+def list_secrets() -> list[str]:
+    res = supabase.table("secrets").select("name").execute()
+    names = [item["name"] for item in res.data or []]
+    _log_audit("*", "list")
+    return names
+
+
+def expire_old(days: int = 90) -> None:
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    res = (
+        supabase.table("secrets")
+        .select("id", "created_at")
+        .lt("created_at", cutoff.isoformat())
+        .execute()
+    )
+    for item in res.data or []:
+        supabase.table("secrets").delete().eq("id", item["id"]).execute()
+        _log_audit(item.get("id", ""), "expire")
+
+
+def run(context: dict) -> dict:
+    """Placeholder to satisfy task loader."""
+    action = context.get("action")
+    if action == "store":
+        store_secret(context["name"], context["value"])
+        return {"status": "stored"}
+    if action == "retrieve":
+        val = retrieve_secret(context["name"])
+        return {"value": val}
+    if action == "delete":
+        delete_secret(context["name"])
+        return {"status": "deleted"}
+    if action == "list":
+        return {"secrets": list_secrets()}
+    return {"status": "no_action"}

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from codex.tasks import secrets as secrets_task
+
 from codex import get_registry, run_task
 from codex.memory import memory_store
 from codex.integrations.make_webhook import router as make_webhook_router
@@ -80,6 +82,29 @@ async def docs_registry() -> Dict[str, Any]:
         for key, value in get_registry().items()
     }
     return registry
+
+
+@app.post("/secrets/store")
+async def store_secret_api(req: dict):
+    secrets_task.store_secret(req["name"], req["value"])
+    return {"status": "stored"}
+
+
+@app.get("/secrets/retrieve/{name}")
+async def retrieve_secret_api(name: str):
+    val = secrets_task.retrieve_secret(name)
+    return {"value": val}
+
+
+@app.delete("/secrets/delete/{name}")
+async def delete_secret_api(name: str):
+    secrets_task.delete_secret(name)
+    return {"status": "deleted"}
+
+
+@app.get("/secrets/list")
+async def list_secrets_api():
+    return {"secrets": secrets_task.list_secrets()}
 
 
 @app.get("/health")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ anthropic
 google-api-python-client
 typer
 rich
+cryptography
 supabase
 langchain
 langchain-community

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -7,6 +7,7 @@ import logging
 
 from codex import run_task
 from codex.memory import memory_store
+from codex.tasks import secrets
 
 logger = logging.getLogger(__name__)
 INTERVAL = 900  # 15 minutes
@@ -22,6 +23,10 @@ async def poll_and_run() -> None:
                     run_task(entry["task"], ctx)
                 except Exception as exc:  # noqa: BLE001
                     logger.error("Auto task failed: %s", exc)
+        try:
+            secrets.expire_old()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Secret expiration failed: %s", exc)
         await asyncio.sleep(INTERVAL)
 
 

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -1,0 +1,10 @@
+from supabase import create_client
+import os
+
+url = os.getenv("SUPABASE_URL")
+key = os.getenv("SUPABASE_SERVICE_KEY")
+
+if not url or not key:
+    raise ValueError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set")
+
+supabase = create_client(url, key)

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -1,0 +1,17 @@
+from cryptography.fernet import Fernet
+import os
+
+FERNET_SECRET = os.getenv("FERNET_SECRET")
+
+if not FERNET_SECRET:
+    raise ValueError("FERNET_SECRET environment variable not set")
+
+fernet = Fernet(FERNET_SECRET)
+
+
+def encrypt(text: str) -> str:
+    return fernet.encrypt(text.encode()).decode()
+
+
+def decrypt(cipher: str) -> str:
+    return fernet.decrypt(cipher.encode()).decode()

--- a/utils/secret_loader.py
+++ b/utils/secret_loader.py
@@ -1,0 +1,5 @@
+from codex.tasks.secrets import retrieve_secret
+
+
+def get_credential(name: str) -> str | None:
+    return retrieve_secret(name)


### PR DESCRIPTION
## Summary
- add Fernet crypto helper for encryption
- integrate Supabase client and secrets management task
- expose secrets CRUD API endpoints
- schedule secret expiration in `scripts/runner.py`
- document vault usage and environment variables
- add cryptography dependency

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ef09d7cc8323a84b801f254f1fea