### PR TITLE
Implement agent planner and diagnostics features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ SUPABASE_URL=https://your-project.supabase.co
 STRIPE_SECRET_KEY=<your Stripe secret key>
 
 # Make.com webhook security (optional)
-MAKE_WEBHOOK_SECRET=<random string>
+MAKE_WEBHOOK_SECRET=secure-make-token
 
 # GitHub webhook secret (optional)
 GITHUB_SECRET=your-github-secret
@@ -25,3 +25,6 @@ TANA_API_KEY=your-key-here
 # Tags used by memory agents
 TANA_AUTO_TAG=auto_execute
 SUMMARY_TAG=summary_candidate
+
+# Enable verbose debugging
+DEBUG_MODE=true

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This repository contains a lightweight task runner and API server used by the Br
 ## Usage
 
 ### CLI
+Run tasks locally using either key/value flags or the JSON wrapper:
 ```bash
-python main.py <task_name> --key value
+python main.py task run '{"task": "create_tana_node", "context": {"content": "CLI test"}}'
 ```
 
 ### API
@@ -34,3 +35,8 @@ curl -X POST http://localhost:10000/secrets/store -H "Content-Type: application/
 ```
 
 You can view available tasks by calling the `/docs/registry` endpoint once the server is running.
+
+Additional helpful endpoints:
+
+- `/webhook/make` - trigger tasks from Make.com.
+- `/diagnostics/state` - view operator status snapshot.

--- a/codex/integrations/make_webhook.py
+++ b/codex/integrations/make_webhook.py
@@ -12,6 +12,8 @@ async def handle_webhook(payload: dict, x_make_secret: str | None = Header(defau
 
     task = payload.get("task")
     context = payload.get("context", {})
+    if isinstance(context, dict):
+        context.setdefault("source", "make-webhook")
     if not task:
         raise HTTPException(status_code=400, detail="'task' is required")
 

--- a/codex/tasks/agent_planner.py
+++ b/codex/tasks/agent_planner.py
@@ -1,0 +1,58 @@
+"""Generate a short task plan with Claude or Gemini and execute it."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from codex.memory import memory_store
+from . import claude_prompt, gemini_prompt, multi_task
+
+TASK_ID = "agent_planner"
+TASK_DESCRIPTION = "Generate a task plan and run it"
+REQUIRED_FIELDS = ["goal"]
+
+logger = logging.getLogger(__name__)
+
+
+def _load_recent(limit: int = 5) -> str:
+    records = memory_store.fetch_all(limit=limit)
+    return "\n\n".join(str(r.get("output") or r) for r in records)
+
+
+def run(context: Dict[str, Any]) -> Dict[str, Any]:
+    goal = context.get("goal")
+    if not goal:
+        return {"error": "missing_goal"}
+
+    max_steps = int(context.get("max_steps", 3))
+    model = context.get("model", "claude")
+
+    mem_text = _load_recent(5)
+
+    prompt = (
+        "You are an AI assistant that creates JSON task plans. "
+        f"Goal: {goal}. Use at most {max_steps} steps. "
+        f"Recent memory:\n{mem_text}\n"
+        "Respond with a JSON object: {\"tasks\": [ ... ]}."
+    )
+
+    if model == "gemini":
+        ai_result = gemini_prompt.run({"prompt": prompt})
+    else:
+        ai_result = claude_prompt.run({"prompt": prompt})
+    raw = ai_result.get("completion", "")
+
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to parse agent output: %s", exc)
+        return {"error": "parse_failed", "raw": raw}
+
+    tasks = data.get("tasks") or []
+    results = {}
+    if tasks:
+        results = multi_task.run({"tasks": tasks})
+
+    return {"generated": tasks, "result": results}

--- a/codex/tasks/ai_prompt_writer.py
+++ b/codex/tasks/ai_prompt_writer.py
@@ -1,0 +1,63 @@
+"""Use Claude or Gemini to craft a useful prompt based on memory."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from codex.memory import memory_store
+from . import claude_prompt, gemini_prompt
+
+TASK_ID = "ai_prompt_writer"
+TASK_DESCRIPTION = "Generate a custom AI prompt"
+REQUIRED_FIELDS = ["purpose", "input"]
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_input(val: str) -> str:
+    if val.startswith("{{") and val.endswith("}}"):
+        token = val[2:-2]
+        if token.startswith("memory:"):
+            arg = token.split(":", 1)[1]
+            try:
+                limit = 1 if arg == "recent" else int(arg)
+            except Exception:  # noqa: BLE001
+                limit = 1
+            mem = memory_store.fetch_all(limit=limit)
+            return "\n".join(str(m.get("output") or m) for m in mem)
+    return val
+
+
+def run(context: Dict[str, Any]) -> Dict[str, Any]:
+    purpose = context.get("purpose")
+    raw_input = context.get("input", "")
+    audience = context.get("audience", "general")
+    model = context.get("model", "claude")
+
+    if not purpose or not raw_input:
+        return {"error": "missing_fields"}
+
+    input_text = _resolve_input(str(raw_input))
+
+    prompt = (
+        "Craft a concise prompt for another AI system. "
+        f"Purpose: {purpose}. Audience: {audience}. "
+        f"Here is the input content:\n{input_text}"
+    )
+
+    if model == "gemini":
+        result = gemini_prompt.run({"prompt": prompt})
+    else:
+        result = claude_prompt.run({"prompt": prompt})
+
+    final_prompt = result.get("completion", "")
+    memory_store.save_memory(
+        {
+            "task": TASK_ID,
+            "input": context,
+            "output": final_prompt,
+            "tags": ["prompt"],
+        }
+    )
+    return {"prompt": final_prompt}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,9 @@
+import os
+
+os.environ.setdefault("FERNET_SECRET", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
+os.environ.setdefault("SUPABASE_URL", "http://example.com")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+
 from fastapi.testclient import TestClient
 from main import app
 
@@ -12,3 +18,9 @@ def test_registry():
     resp = client.get('/docs/registry')
     assert resp.status_code == 200
     assert isinstance(resp.json(), dict)
+
+
+def test_diagnostics_state():
+    resp = client.get('/diagnostics/state')
+    assert resp.status_code == 200
+    assert 'active_tasks' in resp.json()


### PR DESCRIPTION
## Summary
- add agent_planner and ai_prompt_writer tasks
- enhance Tana node executor for feedback logging
- add webhook source tag for Make.com
- CLI improvements and operator diagnostics endpoint
- log errors to a separate file
- update env example and docs
- expand tests for diagnostics

## Testing
- `pytest -q`
- `uvicorn main:app --port 8000 --log-level warning &`
- `curl -s -X POST http://localhost:8000/task/run -H "Content-Type: application/json" -d '{"task":"agent_planner","context":{"goal":"test plan","model":"claude","max_steps":1}}'`
- `curl -s http://localhost:8000/diagnostics/state`
- `curl -s -X POST http://localhost:8000/webhook/make -H "Content-Type: application/json" -H "X-Make-Secret: secure-make-token" -d '{"task":"claude_prompt","context":{"prompt":"hi"}}'`


------
https://chatgpt.com/codex/tasks/task_e_686807d18438832397a9420f0c611e31