### PR TITLE
Add voice sync endpoints and deploy watcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ TANA_API_KEY=your-key-here
 TANA_AUTO_TAG=auto_execute
 SUMMARY_TAG=summary_candidate
 
+# Deployment sync watcher
+GITHUB_DEPLOY_HASH_KEY=
+TANA_NODE_CALLBACK=true
+VOICE_UPLOAD_RETENTION_DAYS=30
+
 # Enable verbose debugging
 DEBUG_MODE=true
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ Additional helpful endpoints:
 
 - `/webhook/make` - trigger tasks from Make.com.
 - `/diagnostics/state` - view operator status snapshot.
+- `/voice/status` - latest voice transcript processing info.
+- `/voice/history` - recent transcription records.

--- a/codex/tasks/multi_task.py
+++ b/codex/tasks/multi_task.py
@@ -74,10 +74,11 @@ def run(context: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(tasks, list) or not tasks:
         return {"error": "tasks must be a non-empty list"}
 
+    extra = {k: v for k, v in context.items() if k not in {"tasks"}}
     results: List[Any] = []
     for task_def in tasks:
         task_id = task_def.get("task")
-        task_ctx = task_def.get("context", {})
+        task_ctx = {**extra, **task_def.get("context", {})}
         task_ctx = _resolve_context(task_ctx, results)
         result = run_task(task_id, task_ctx)
         results.append(result)

--- a/scripts/deploy_watcher.py
+++ b/scripts/deploy_watcher.py
@@ -1,0 +1,49 @@
+import os
+import time
+import httpx
+
+INTERVAL = 900  # 15 minutes
+REPO = os.getenv("GITHUB_REPO", "mwwoodworth/fastapi-operator-env")
+STATE_FILE = os.getenv("DEPLOY_HASH_FILE", "last_deploy_hash.txt")
+WEBHOOK = os.getenv("DEPLOY_WEBHOOK", "http://localhost:10000/webhook/github")
+
+def _get_latest_commit() -> str:
+    url = f"https://api.github.com/repos/{REPO}/commits/main"
+    resp = httpx.get(url, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("sha", "")
+
+
+def _load_last() -> str:
+    if os.path.exists(STATE_FILE):
+        return open(STATE_FILE).read().strip()
+    return ""
+
+
+def _save_last(sha: str) -> None:
+    with open(STATE_FILE, "w") as f:
+        f.write(sha)
+
+
+def _trigger_deploy(sha: str) -> None:
+    try:
+        httpx.post(WEBHOOK, json={"sha": sha}, timeout=10)
+    except Exception as exc:  # noqa: BLE001
+        print(f"deploy webhook failed: {exc}")
+
+
+def main() -> None:
+    while True:
+        try:
+            latest = _get_latest_commit()
+            last = _load_last()
+            if latest and latest != last:
+                _trigger_deploy(latest)
+                _save_last(latest)
+        except Exception as exc:  # noqa: BLE001
+            print(f"deploy watcher error: {exc}")
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -24,3 +24,10 @@ def test_diagnostics_state():
     resp = client.get('/diagnostics/state')
     assert resp.status_code == 200
     assert 'active_tasks' in resp.json()
+
+
+def test_voice_endpoints():
+    resp = client.get('/voice/history')
+    assert resp.status_code == 200
+    resp = client.get('/voice/status')
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expand `multi_task` to propagate extra context
- record voice uploads with transcript metadata and push to Tana
- add `/voice/history` and new `/voice/status` endpoints
- enhance `/webhook/status-update` to callback to Tana
- provide deployment watcher utility
- expose configuration examples in `.env.example`
- mention voice routes in README
- test new routes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868360996e08323bb96f922656e72df