### PR TITLE
Implement mobile inbox features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,7 @@ VOICE_UPLOAD_DIR=uploads/
 CHAT_SYSTEM_PROMPT=You are BrainOps Operator, a fast, reliable assistant for project execution.
 TRACE_FEEDBACK_ENABLED=true
 TRACE_VIEW_LIMIT=50
+
+# Agent inbox settings
+INBOX_SUPABASE_TABLE=agent_inbox
+INBOX_SUMMARIZER_MODEL=claude

--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ Additional helpful endpoints:
 - `/diagnostics/state` - view operator status snapshot.
 - `/voice/status` - latest voice transcript processing info.
 - `/voice/history` - recent transcription records.
+- `/agent/inbox` - pending task queue.
+- `/agent/inbox/approve` - approve or reject tasks.
+- `/agent/inbox/summary` - inbox counts overview.
+- `/dashboard/full` - extended operator metrics.
+- `/mobile/task` - quick mobile task capture.

--- a/codex/memory/agent_inbox.py
+++ b/codex/memory/agent_inbox.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+"""Agent inbox queue stored in Supabase or fallback JSON file."""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    from supabase import create_client
+    SUPABASE_AVAILABLE = True
+except Exception:  # noqa: BLE001
+    SUPABASE_AVAILABLE = False
+
+_SUPABASE_URL = os.getenv("SUPABASE_URL")
+_SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
+_TABLE = os.getenv("INBOX_SUPABASE_TABLE", "agent_inbox")
+
+_client = None
+if SUPABASE_AVAILABLE and _SUPABASE_URL and _SUPABASE_KEY:
+    try:  # pragma: no cover - network
+        _client = create_client(_SUPABASE_URL, _SUPABASE_KEY)
+    except Exception:  # noqa: BLE001
+        _client = None
+
+_LOG_FILE = Path("logs/inbox.json")
+
+from codex.tasks import ai_inbox_summarizer
+
+
+def _append_file(entry: Dict[str, Any]) -> None:
+    _LOG_FILE.parent.mkdir(exist_ok=True)
+    history: List[Dict[str, Any]] = []
+    if _LOG_FILE.exists():
+        try:
+            history = json.loads(_LOG_FILE.read_text())
+        except Exception:  # noqa: BLE001
+            history = []
+    history.append(entry)
+    _LOG_FILE.write_text(json.dumps(history[-200:], indent=2))
+
+
+def add_to_inbox(task_id: str, context: Dict[str, Any], origin: str, model: str | None = None) -> Dict[str, Any]:
+    """Queue a task for approval and store summary."""
+    model = model or os.getenv("INBOX_SUMMARIZER_MODEL", "claude")
+    summary = ai_inbox_summarizer.run({"context": context, "model": model})
+    entry = {
+        "task_id": task_id,
+        "origin": origin,
+        "model": model,
+        "context": context,
+        "status": "pending",
+        "timestamp": datetime.utcnow().isoformat(),
+        "summary": summary,
+    }
+    if _client:
+        try:  # pragma: no cover - network
+            _client.table(_TABLE).insert(entry).execute()
+        except Exception:  # noqa: BLE001
+            _append_file(entry)
+    else:
+        _append_file(entry)
+    return entry
+
+
+def get_pending_tasks(limit: int = 10) -> List[Dict[str, Any]]:
+    """Return pending inbox tasks."""
+    if _client:
+        try:  # pragma: no cover - network
+            res = (
+                _client.table(_TABLE)
+                .select("*")
+                .eq("status", "pending")
+                .order("timestamp", desc=True)
+                .limit(limit)
+                .execute()
+            )
+            return list(res.data or [])
+        except Exception:  # noqa: BLE001
+            pass
+    if _LOG_FILE.exists():
+        try:
+            data = json.loads(_LOG_FILE.read_text())
+            return [d for d in data if d.get("status") == "pending"][-limit:]
+        except Exception:  # noqa: BLE001
+            return []
+    return []
+
+
+def _update_file(task_id: str, status: str, notes: str) -> None:
+    if not _LOG_FILE.exists():
+        return
+    try:
+        data = json.loads(_LOG_FILE.read_text())
+    except Exception:  # noqa: BLE001
+        return
+    for item in data:
+        if item.get("task_id") == task_id:
+            item["status"] = status
+            item["notes"] = notes
+            item["updated"] = datetime.utcnow().isoformat()
+            break
+    _LOG_FILE.write_text(json.dumps(data, indent=2))
+
+
+def mark_as_resolved(task_id: str, status: str, notes: str) -> None:
+    """Update inbox item status with optional notes."""
+    if _client:
+        try:  # pragma: no cover - network
+            _client.table(_TABLE).update({"status": status, "notes": notes}).eq("task_id", task_id).execute()
+        except Exception:  # noqa: BLE001
+            _update_file(task_id, status, notes)
+    else:
+        _update_file(task_id, status, notes)
+
+
+def get_task(task_id: str) -> Optional[Dict[str, Any]]:
+    """Retrieve a single inbox item."""
+    if _client:
+        try:  # pragma: no cover - network
+            res = _client.table(_TABLE).select("*").eq("task_id", task_id).limit(1).execute()
+            if res.data:
+                return res.data[0]
+        except Exception:  # noqa: BLE001
+            pass
+    if _LOG_FILE.exists():
+        try:
+            data = json.loads(_LOG_FILE.read_text())
+            for item in data:
+                if item.get("task_id") == task_id:
+                    return item
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def get_summary() -> Dict[str, Any]:
+    """Return summary counts and last decision."""
+    pending = 0
+    approved = 0
+    last_decision = None
+    records: List[Dict[str, Any]] = []
+    if _client:
+        try:  # pragma: no cover - network
+            all_items = _client.table(_TABLE).select("*").order("timestamp", desc=True).execute()
+            records = list(all_items.data or [])
+        except Exception:  # noqa: BLE001
+            records = []
+    elif _LOG_FILE.exists():
+        try:
+            records = json.loads(_LOG_FILE.read_text())
+        except Exception:  # noqa: BLE001
+            records = []
+    for item in records:
+        status = item.get("status")
+        if status == "pending":
+            pending += 1
+        if status == "approved":
+            approved += 1
+    if records:
+        for item in reversed(records):
+            if item.get("status") != "pending":
+                last_decision = item.get("notes")
+                break
+    return {"pending": pending, "approved": approved, "last_decision": last_decision}

--- a/codex/tasks/__init__.py
+++ b/codex/tasks/__init__.py
@@ -19,5 +19,6 @@ from . import (
     gemini_memory_agent,
     github_push_trigger,
     tana_node_executor,
+    ai_inbox_summarizer,
     secrets,
 )

--- a/codex/tasks/ai_inbox_summarizer.py
+++ b/codex/tasks/ai_inbox_summarizer.py
@@ -1,0 +1,41 @@
+"""Summarize task context for inbox preview."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from utils.ai_logging import log_prompt
+from . import claude_prompt, gemini_prompt
+
+TASK_ID = "ai_inbox_summarizer"
+TASK_DESCRIPTION = "Summarize task context for quick review"
+REQUIRED_FIELDS = ["context"]
+
+logger = logging.getLogger(__name__)
+
+
+def run(context: Dict[str, Any]) -> Dict[str, Any]:
+    ctx = context.get("context") or {}
+    model = context.get("model") or os.getenv("INBOX_SUMMARIZER_MODEL", "claude")
+    if model not in {"claude", "gemini"}:
+        return {
+            "summary": str(ctx)[:200],
+            "importance": "",
+            "next_steps": "",
+            "executed_by": model,
+        }
+    prompt = (
+        "Provide a short JSON summary for the following task context. "
+        "Return keys 'summary', 'importance', 'next_steps'.\n" + json.dumps(ctx)
+    )
+    ai_result = claude_prompt.run({"prompt": prompt}) if model == "claude" else gemini_prompt.run({"prompt": prompt})
+    raw = ai_result.get("completion", "")
+    log_prompt(model, TASK_ID, prompt, raw)
+    try:
+        data = json.loads(raw)
+    except Exception:  # noqa: BLE001
+        data = {"summary": raw, "importance": "", "next_steps": ""}
+    data["executed_by"] = ai_result.get("executed_by", model)
+    return data

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,7 @@ import os
 os.environ.setdefault("FERNET_SECRET", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
 os.environ.setdefault("SUPABASE_URL", "http://example.com")
 os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+os.environ.setdefault("INBOX_SUMMARIZER_MODEL", "none")
 
 from fastapi.testclient import TestClient
 from main import app
@@ -30,4 +31,19 @@ def test_voice_endpoints():
     resp = client.get('/voice/history')
     assert resp.status_code == 200
     resp = client.get('/voice/status')
+    assert resp.status_code == 200
+
+
+def test_inbox_routes():
+    from codex.memory import agent_inbox
+
+    item = agent_inbox.add_to_inbox("sample_task", {"foo": "bar"}, "test")
+    resp = client.get('/agent/inbox')
+    assert resp.status_code == 200
+    tasks = resp.json()
+    assert isinstance(tasks, list)
+    assert any(t["task_id"] == item["task_id"] for t in tasks)
+    resp = client.post('/agent/inbox/approve', json={"task_id": item["task_id"], "decision": "reject"})
+    assert resp.status_code == 200
+    resp = client.get('/agent/inbox/summary')
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- create agent inbox queue with Supabase fallback
- add Claude/Gemini inbox summarizer task
- update voice upload to queue tasks
- expose inbox approval, summary, and mobile routes
- extend dashboard with inbox metrics
- document new environment variables and endpoints
- test inbox flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683bbed1b48323b568ed77ba6fb3d0