### PR TITLE
Add Copilot V2 dashboard route

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Additional helpful endpoints:
 - `/dashboard/full` - extended operator metrics.
 - `/dashboard/metrics` - summary counts of tasks and memory logs.
 - `/dashboard/ui` - live dashboard interface.
+- `/dashboard/copilot-v2` - memory-assisted Copilot v2.
 - `/memory/search` - search memories with filters.
 - `/logs/errors` - recent error entries.
 - `/mobile/task` - quick mobile task capture.

--- a/dashboard_ui/app/dashboard/copilot-v2/page.tsx
+++ b/dashboard_ui/app/dashboard/copilot-v2/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import CopilotV2 from '../../../components/CopilotV2';
+
+export default function CopilotV2Page() {
+  return (
+    <div className="h-full flex flex-col">
+      <CopilotV2 />
+    </div>
+  );
+}

--- a/dashboard_ui/app/dashboard/layout.tsx
+++ b/dashboard_ui/app/dashboard/layout.tsx
@@ -15,6 +15,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           <Link href="/dashboard" className="block">Home</Link>
           <Link href="/dashboard/memory" className="block">Memory</Link>
           <Link href="/dashboard/copilot" className="block">Copilot</Link>
+          <Link href="/dashboard/copilot-v2" className="block">Copilot v2</Link>
           <Link href="/dashboard/sync" className="block">Sync</Link>
           <Link href="/dashboard/documents" className="block">Documents</Link>
           <Link href="/dashboard/export" className="block">Export</Link>

--- a/dashboard_ui/app/dashboard/page.tsx
+++ b/dashboard_ui/app/dashboard/page.tsx
@@ -18,6 +18,11 @@ export default function DashboardHome() {
           </Link>
         </li>
         <li>
+          <Link href="/dashboard/copilot-v2" className="text-blue-600 underline">
+            Copilot v2
+          </Link>
+        </li>
+        <li>
           <Link href="/dashboard/sync" className="text-blue-600 underline">
             Claude Sync
           </Link>

--- a/dashboard_ui/components/CopilotHeader.tsx
+++ b/dashboard_ui/components/CopilotHeader.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React from 'react';
+
+interface Props {
+  model: string;
+  onModelChange: (m: string) => void;
+}
+
+export default function CopilotHeader({ model, onModelChange }: Props) {
+  return (
+    <div className="flex items-center justify-between border-b p-2">
+      <h2 className="font-semibold">Copilot V2</h2>
+      <select
+        className="border rounded px-2 py-1 text-sm"
+        value={model}
+        onChange={e => onModelChange(e.target.value)}
+      >
+        <option value="claude">Claude</option>
+        <option value="chatgpt">ChatGPT</option>
+        <option value="gemini">Gemini</option>
+        <option value="disabled">Disabled</option>
+      </select>
+    </div>
+  );
+}

--- a/dashboard_ui/components/CopilotResponse.tsx
+++ b/dashboard_ui/components/CopilotResponse.tsx
@@ -1,0 +1,22 @@
+'use client';
+import React from 'react';
+
+interface Props {
+  role: 'user' | 'ai';
+  text: string;
+}
+
+export default function CopilotResponse({ role, text }: Props) {
+  const isUser = role === 'user';
+  return (
+    <div className={`w-full flex ${isUser ? 'justify-end' : 'justify-start'}`}> 
+      <div
+        className={`whitespace-pre-wrap max-w-[80%] px-3 py-2 rounded text-sm ${
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted'
+        }`}
+      >
+        {text}
+      </div>
+    </div>
+  );
+}

--- a/dashboard_ui/components/CopilotV2.tsx
+++ b/dashboard_ui/components/CopilotV2.tsx
@@ -1,0 +1,88 @@
+'use client';
+import React, { useState, useRef } from 'react';
+import CopilotHeader from './CopilotHeader';
+import CopilotResponse from './CopilotResponse';
+import { postMemoryQuery, writeMemory } from '../utils/api';
+import { promptClaude, promptChatGPT } from '../utils/ai';
+
+interface Message { role: 'user' | 'ai'; content: string; }
+
+export default function CopilotV2() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [model, setModel] = useState('claude');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  async function send() {
+    if (!input.trim() || model === 'disabled') return;
+    const userText = input;
+    setInput('');
+    setMessages(m => [...m, { role: 'user', content: userText }]);
+    setLoading(true);
+    try {
+      const mem = await postMemoryQuery(userText);
+      const top = mem.results?.[0]?.content_chunk || '';
+      const prompt = `Context:\n${top}\n\nPrompt:\n${userText}`;
+      const aiFunc = model === 'claude' ? promptClaude : promptChatGPT;
+      const res = await aiFunc(prompt);
+      const full = res.result || res.response || res.completion || '';
+      setMessages(m => [...m, { role: 'ai', content: '' }]);
+      let partial = '';
+      for (const ch of full) {
+        partial += ch;
+        setMessages(m => {
+          const copy = [...m];
+          copy[copy.length - 1] = { role: 'ai', content: partial };
+          return copy;
+        });
+        await new Promise(r => setTimeout(r, 20));
+      }
+      writeMemory({
+        project_id: 'chat',
+        title: userText.slice(0, 40),
+        content: `${userText}\n${full}`,
+        author_id: 'user',
+      }).catch(() => {});
+    } catch (e) {
+      setMessages(m => [...m, { role: 'ai', content: 'Error' }]);
+    } finally {
+      setLoading(false);
+      setTimeout(() => endRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <CopilotHeader model={model} onModelChange={setModel} />
+      <div className="flex-1 overflow-auto p-2 space-y-2">
+        {messages.map((m, idx) => (
+          <CopilotResponse key={idx} role={m.role} text={m.content} />
+        ))}
+        {loading && <p className="text-sm opacity-60">Loading...</p>}
+        <div ref={endRef} />
+      </div>
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          send();
+        }}
+        className="p-2 border-t flex gap-2"
+      >
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Ask the copilot..."
+          className="flex-1 border px-3 py-2 rounded"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-primary text-primary-foreground px-4 py-2 rounded"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/dashboard_ui/utils/ai.ts
+++ b/dashboard_ui/utils/ai.ts
@@ -1,0 +1,13 @@
+export async function promptClaude(prompt: string) {
+  return fetch('/api/claude', {
+    method: 'POST',
+    body: JSON.stringify({ prompt }),
+  }).then(r => r.json());
+}
+
+export async function promptChatGPT(prompt: string) {
+  return fetch('/api/chatgpt', {
+    method: 'POST',
+    body: JSON.stringify({ prompt }),
+  }).then(r => r.json());
+}

--- a/dashboard_ui/utils/api.ts
+++ b/dashboard_ui/utils/api.ts
@@ -24,3 +24,16 @@ export async function updateDocument(id: string, content: string) {
     body: JSON.stringify({ document_id: id, content }),
   }).then(r => r.json());
 }
+
+export async function writeMemory(entry: {
+  project_id: string;
+  title: string;
+  content: string;
+  author_id: string;
+}) {
+  return fetch(`${API_BASE}/memory/write`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(entry),
+  }).then(r => r.json());
+}


### PR DESCRIPTION
## Summary
- add `/dashboard/copilot-v2` route for memory-assisted copilot
- build CopilotV2 components with model toggle and streamed output
- expose `promptClaude()` and `promptChatGPT()` utilities
- link Copilot V2 in dashboard navigation and README

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e01f7cd5083238ff418bbc2d81154