### PR TITLE
feat(ai): persistent assistant/chat + commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,14 @@ Include the dashboard in another site using:
 ```
 The same snippet works in Tana, Google Sites or any platform that allows iframes.
 
--### Customization
+### Customization
 
 - API endpoint base URL is configured with `NEXT_PUBLIC_API_BASE`.
 - Set `NEXT_PUBLIC_AUTH_HEADER` if your FastAPI server requires HTTP Basic or JWT auth (e.g. `"Basic dXNlcjpwYXNz"` or `"Bearer <token>").
 - Branding and styling can be tweaked in `dashboard_ui/styles` and React components.
+
+### BrainOps AI Assistant
+
+The dashboard includes a persistent chat widget that proxies to the FastAPI `/chat` endpoint via `/api/assistant/chat`.
+Use it to summarize memory or trigger tasks. Conversations are saved to Supabase for later review.
 

--- a/dashboard_ui/app/api/assistant/chat/route.ts
+++ b/dashboard_ui/app/api/assistant/chat/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { message } = await req.json();
+  if (!message) {
+    return NextResponse.json({ error: 'message required' }, { status: 400 });
+  }
+  const base = process.env.NEXT_PUBLIC_API_BASE || '';
+  try {
+    const res = await fetch(`${base}/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    });
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (e) {
+    return NextResponse.json({ error: 'request failed' }, { status: 500 });
+  }
+}

--- a/dashboard_ui/app/dashboard/generate/page.tsx
+++ b/dashboard_ui/app/dashboard/generate/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ContentGenerator from '../../../components/ContentGenerator';
+
+export default function GeneratePage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Generate Content</h2>
+      <ContentGenerator />
+    </div>
+  );
+}

--- a/dashboard_ui/app/dashboard/layout.tsx
+++ b/dashboard_ui/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import '../../styles/globals.css';
+import AssistantChatWidget from '../../components/AssistantChatWidget';
 
 export const metadata = {
   title: 'BrainOps Dashboard',
@@ -18,12 +19,14 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           <Link href="/dashboard/copilot-v2" className="block">Copilot v2</Link>
           <Link href="/dashboard/sync" className="block">Sync</Link>
           <Link href="/dashboard/documents" className="block">Documents</Link>
+          <Link href="/dashboard/generate" className="block">Generate</Link>
           <Link href="/dashboard/export" className="block">Export</Link>
         </nav>
       </aside>
       <div className="flex-1 p-4">
         {children}
       </div>
+      <AssistantChatWidget />
     </div>
   );
 }

--- a/dashboard_ui/components/AssistantChatWidget.tsx
+++ b/dashboard_ui/components/AssistantChatWidget.tsx
@@ -1,0 +1,70 @@
+'use client';
+import React, { useState } from 'react';
+
+interface Msg { role: 'user' | 'assistant'; text: string; }
+
+export default function AssistantChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [msgs, setMsgs] = useState<Msg[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function send() {
+    if (!input.trim()) return;
+    const user = input;
+    setInput('');
+    setMsgs(m => [...m, { role: 'user', text: user }]);
+    setLoading(true);
+    try {
+      const res = await fetch('/api/assistant/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: user }),
+      });
+      const data = await res.json();
+      const text = data.response || data.result || data.completion || '';
+      setMsgs(m => [...m, { role: 'assistant', text }]);
+    } catch (e) {
+      setMsgs(m => [...m, { role: 'assistant', text: 'Error' }]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="fixed bottom-4 right-4 bg-primary text-primary-foreground px-4 py-2 rounded-full"
+      >
+        {open ? 'Close' : 'Chat'}
+      </button>
+      {open && (
+        <div className="fixed bottom-16 right-4 bg-background border rounded shadow-lg w-80 max-h-96 flex flex-col">
+          <div className="flex-1 p-2 overflow-auto space-y-2">
+            {msgs.map((m, i) => (
+              <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+                <span className="text-sm whitespace-pre-wrap">{m.text}</span>
+              </div>
+            ))}
+            {loading && <p className="text-sm opacity-50">...</p>}
+          </div>
+          <form
+            onSubmit={e => { e.preventDefault(); send(); }}
+            className="p-2 border-t flex gap-2"
+          >
+            <input
+              className="flex-1 border px-2 py-1 rounded"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              placeholder="Message"
+            />
+            <button type="submit" disabled={loading} className="bg-primary text-primary-foreground px-3 py-1 rounded">
+              Send
+            </button>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/dashboard_ui/components/ContentGenerator.tsx
+++ b/dashboard_ui/components/ContentGenerator.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function ContentGenerator() {
+  const [prompt, setPrompt] = useState('');
+  const [output, setOutput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function generate() {
+    if (!prompt.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/assistant/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: prompt }),
+      });
+      const data = await res.json();
+      setOutput(data.response || data.result || '');
+    } catch (e) {
+      setOutput('Error generating');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <textarea
+        className="w-full border p-2 rounded"
+        rows={4}
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        placeholder="Enter content prompt"
+      />
+      <button onClick={generate} disabled={loading} className="bg-primary text-primary-foreground px-4 py-2 rounded">
+        Generate
+      </button>
+      {loading && <p>Loading...</p>}
+      {output && (
+        <div className="border p-2 rounded bg-muted">
+          <pre className="whitespace-pre-wrap text-sm">{output}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard_ui/components/Layout.js
+++ b/dashboard_ui/components/Layout.js
@@ -1,5 +1,6 @@
 import ThemeToggle from './ThemeToggle';
 import InstallPrompt from './InstallPrompt';
+import AssistantChatWidget from './AssistantChatWidget';
 
 export default function Layout({ children, theme, setTheme }) {
   return (
@@ -12,6 +13,7 @@ export default function Layout({ children, theme, setTheme }) {
       <footer className="text-center text-sm mt-4 opacity-75">
         Powered by FastAPI
       </footer>
+      <AssistantChatWidget />
       <InstallPrompt />
     </div>
   );

--- a/tests/test_dashboard_components.py
+++ b/tests/test_dashboard_components.py
@@ -11,3 +11,15 @@ def test_export_panel_component_exists():
     path = pathlib.Path('dashboard_ui/components/ExportPanel.tsx')
     text = path.read_text()
     assert 'export default function' in text
+
+
+def test_assistant_chat_widget_exists():
+    path = pathlib.Path('dashboard_ui/components/AssistantChatWidget.tsx')
+    text = path.read_text()
+    assert 'export default function' in text
+
+
+def test_assistant_chat_api_route_exists():
+    path = pathlib.Path('dashboard_ui/app/api/assistant/chat/route.ts')
+    text = path.read_text()
+    assert 'async function POST' in text


### PR DESCRIPTION
## Summary
- add persistent AssistantChatWidget UI
- integrate widget into dashboard layouts
- proxy `/api/assistant/chat` route to FastAPI backend
- add content generation component and page
- document BrainOps AI Assistant usage
- test for new dashboard files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e823e305c8323933679792c2db58a