### PR TITLE
feat: chat/task schema

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./app.db

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+import db.models  # noqa: F401
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = db.models.Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(config.get_section(config.config_ini_section), poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,18 @@
+<%text>#
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+</%text>
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+${imports if imports else ""}
+
+def upgrade() -> None:
+${upgrades if upgrades else "    pass"}
+
+def downgrade() -> None:
+${downgrades if downgrades else "    pass"}

--- a/alembic/versions/0001_chat_task_schema.py
+++ b/alembic/versions/0001_chat_task_schema.py
@@ -1,0 +1,70 @@
+"""add chat and task schema"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "threads",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("title", sa.String(length=255)),
+        sa.Column("participants", sa.ARRAY(sa.String)),
+        sa.Column("project_id", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("thread_id", sa.Integer, sa.ForeignKey("threads.id")),
+        sa.Column("sender", sa.String(length=50)),
+        sa.Column("recipient", sa.String(length=50), nullable=True),
+        sa.Column("content", sa.Text),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("metadata", sa.JSON),
+        sa.Column("attachments", sa.JSON, nullable=True),
+    )
+    op.create_table(
+        "tasks",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("title", sa.String(length=255)),
+        sa.Column("description", sa.Text),
+        sa.Column("status", sa.String(length=50)),
+        sa.Column("assigned_to", sa.String(length=50)),
+        sa.Column("created_by", sa.String(length=50)),
+        sa.Column("due_date", sa.DateTime, nullable=True),
+        sa.Column("parent_task", sa.Integer, sa.ForeignKey("tasks.id"), nullable=True),
+        sa.Column("thread_id", sa.Integer, sa.ForeignKey("threads.id"), nullable=True),
+        sa.Column("priority", sa.Integer),
+        sa.Column("tags", sa.ARRAY(sa.String)),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+    op.create_table(
+        "files",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("filename", sa.String(length=255)),
+        sa.Column("uploader", sa.String(length=50)),
+        sa.Column("path", sa.String(length=255)),
+        sa.Column("thread_id", sa.Integer, sa.ForeignKey("threads.id"), nullable=True),
+        sa.Column("task_id", sa.Integer, sa.ForeignKey("tasks.id"), nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("metadata", sa.JSON),
+    )
+    op.create_index("ix_messages_thread_sender", "messages", ["thread_id", "sender"])
+    op.create_index("ix_tasks_assigned_status", "tasks", ["assigned_to", "status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tasks_assigned_status", table_name="tasks")
+    op.drop_index("ix_messages_thread_sender", table_name="messages")
+    op.drop_table("files")
+    op.drop_table("tasks")
+    op.drop_table("messages")
+    op.drop_table("threads")

--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+try:
+    from sqlalchemy import (
+        JSON,
+        Column,
+        DateTime,
+        ForeignKey,
+        Integer,
+        String,
+        Text,
+        Index,
+    )
+    from sqlalchemy.dialects.postgresql import ARRAY
+    from sqlalchemy.orm import declarative_base, relationship
+    SQLALCHEMY_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    SQLALCHEMY_AVAILABLE = False
+
+    class Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    JSON = DateTime = ForeignKey = Integer = String = Text = Index = Column = Dummy
+
+    def declarative_base():  # type: ignore
+        class Base:
+            pass
+
+        return Base
+
+    def relationship(*args, **kwargs):  # type: ignore
+        return None
+
+    class ARRAY(list):
+        pass
+
+Base = declarative_base()
+
+class Thread(Base):
+    __tablename__ = "threads"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String(255))
+    participants = Column(ARRAY(String))
+    project_id = Column(String(255), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    messages = relationship("Message", back_populates="thread")
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True)
+    thread_id = Column(Integer, ForeignKey("threads.id"))
+    sender = Column(String(50))
+    recipient = Column(String(50), nullable=True)
+    content = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    metadata = Column(JSON)
+    attachments = Column(JSON, nullable=True)
+
+    thread = relationship("Thread", back_populates="messages")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String(255))
+    description = Column(Text)
+    status = Column(String(50))
+    assigned_to = Column(String(50))
+    created_by = Column(String(50))
+    due_date = Column(DateTime, nullable=True)
+    parent_task = Column(Integer, ForeignKey("tasks.id"), nullable=True)
+    thread_id = Column(Integer, ForeignKey("threads.id"), nullable=True)
+    priority = Column(Integer)
+    tags = Column(ARRAY(String))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    parent = relationship("Task", remote_side=[id])
+    thread = relationship("Thread")
+    files = relationship("File", back_populates="task")
+
+
+class File(Base):
+    __tablename__ = "files"
+
+    id = Column(Integer, primary_key=True)
+    filename = Column(String(255))
+    uploader = Column(String(50))
+    path = Column(String(255))
+    thread_id = Column(Integer, ForeignKey("threads.id"), nullable=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    metadata = Column(JSON)
+
+    thread = relationship("Thread")
+    task = relationship("Task", back_populates="files")
+
+
+# Indexes
+Index("ix_messages_thread_sender", Message.thread_id, Message.sender)
+Index("ix_tasks_assigned_status", Task.assigned_to, Task.status)

--- a/db/session.py
+++ b/db/session.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+
+try:
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    SQLALCHEMY_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    SQLALCHEMY_AVAILABLE = False
+
+    def create_engine(*args, **kwargs):  # type: ignore
+        return None
+
+    class sessionmaker:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, *args, **kwargs):
+            return None
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+engine = create_engine(DATABASE_URL) if SQLALCHEMY_AVAILABLE else None
+SessionLocal = sessionmaker(bind=engine) if SQLALCHEMY_AVAILABLE else lambda: None
+
+
+def init_db() -> None:
+    if not SQLALCHEMY_AVAILABLE:
+        return
+    from .models import Base
+
+    Base.metadata.create_all(bind=engine)

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import secrets as pysecrets
 from pydantic import BaseModel
 from utils.slack import send_slack_message
+from db.session import init_db
 
 from codex.tasks import (
     secrets as secrets_task,
@@ -98,6 +99,7 @@ async def lifespan(app: FastAPI):
         logger.warning("Missing env vars: %s", ", ".join(missing))
     tasks = ", ".join(get_registry().keys())
     logger.info("Available tasks: %s", tasks)
+    init_db()
     yield
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ langchain
 langchain-community
 faiss-cpu
 python-multipart
+SQLAlchemy>=2.0
+alembic


### PR DESCRIPTION
## Summary
- add optional SQLAlchemy models for threads, messages, tasks, and files
- initialise DB on startup
- include Alembic config and migration for new schema
- list SQLAlchemy and Alembic in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed6d1ef688323972b526133fee7a4