### PR TITLE
feat: chat task api

### DIFF
--- a/chat_task_api.py
+++ b/chat_task_api.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, Form
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from db.models import File as DBFile, Message, Task, Thread
+from db.session import SessionLocal
+
+security = HTTPBasic(auto_error=False)
+USERS = {}
+if os.getenv("BASIC_AUTH_USERS"):
+    try:
+        USERS = json.loads(os.getenv("BASIC_AUTH_USERS", "{}"))
+    except Exception:
+        USERS = {}
+AGENT_KEYS = {}
+if os.getenv("AGENT_KEYS"):
+    try:
+        AGENT_KEYS = json.loads(os.getenv("AGENT_KEYS", "{}"))
+    except Exception:
+        AGENT_KEYS = {}
+
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_identity(
+    request: Request,
+    credentials: HTTPBasicCredentials = Depends(security),
+) -> str:
+    """Authenticate via Basic auth or agent key."""
+    if not USERS and not AGENT_KEYS:
+        return "anonymous"
+    if USERS and credentials:
+        pw = USERS.get(credentials.username)
+        if pw and credentials.password == pw:
+            return credentials.username
+    key = request.headers.get("X-Agent-Key")
+    if AGENT_KEYS and key:
+        for name, val in AGENT_KEYS.items():
+            if val == key:
+                return f"agent:{name}"
+    raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+class ThreadCreate(BaseModel):
+    title: Optional[str] = None
+    participants: List[str] = []
+    project_id: Optional[str] = None
+
+
+class ThreadUpdate(BaseModel):
+    title: Optional[str] = None
+    add_participants: List[str] = []
+
+
+@router.post("/threads")
+def create_thread(payload: ThreadCreate, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Create a new chat thread."""
+    thread = Thread(title=payload.title, participants=payload.participants, project_id=payload.project_id)
+    db.add(thread)
+    db.commit()
+    db.refresh(thread)
+    return {"id": thread.id}
+
+
+@router.get("/threads")
+def list_threads(db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Return all threads."""
+    threads = db.query(Thread).all()
+    return threads
+
+
+@router.get("/threads/{thread_id}")
+def get_thread(thread_id: int, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Fetch a single thread by ID."""
+    thread = db.query(Thread).get(thread_id)
+    if not thread:
+        raise HTTPException(status_code=404, detail="not found")
+    return thread
+
+
+@router.patch("/threads/{thread_id}")
+def update_thread(thread_id: int, payload: ThreadUpdate, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Update thread title or participants."""
+    thread = db.query(Thread).get(thread_id)
+    if not thread:
+        raise HTTPException(status_code=404, detail="not found")
+    if payload.title is not None:
+        thread.title = payload.title
+    if payload.add_participants:
+        existing = thread.participants or []
+        thread.participants = list(set(existing + payload.add_participants))
+    db.commit()
+    db.refresh(thread)
+    return thread
+
+
+class MessageCreate(BaseModel):
+    thread_id: int
+    sender: str
+    content: str
+    recipient: Optional[str] = None
+    metadata: Optional[dict] = None
+    attachments: Optional[dict] = None
+
+
+class MessageUpdate(BaseModel):
+    content: Optional[str] = None
+    metadata: Optional[dict] = None
+    attachments: Optional[dict] = None
+
+
+@router.post("/messages")
+def create_message(payload: MessageCreate, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Create a message in a thread."""
+    msg = Message(
+        thread_id=payload.thread_id,
+        sender=payload.sender,
+        recipient=payload.recipient,
+        content=payload.content,
+        meta=payload.metadata,
+        attachments=payload.attachments,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return {"id": msg.id}
+
+
+@router.get("/messages")
+def list_messages(
+    thread: int | None = None,
+    sender: str | None = None,
+    db: Session = Depends(get_db),
+    _: str = Depends(get_identity),
+):
+    """List messages filtered by thread or sender."""
+    query = db.query(Message)
+    if thread is not None:
+        query = query.filter(Message.thread_id == thread)
+    if sender is not None:
+        query = query.filter(Message.sender == sender)
+    return query.all()
+
+
+@router.patch("/messages/{message_id}")
+def edit_message(message_id: int, payload: MessageUpdate, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Edit message content or metadata."""
+    msg = db.query(Message).get(message_id)
+    if not msg:
+        raise HTTPException(status_code=404, detail="not found")
+    if payload.content is not None:
+        msg.content = payload.content
+    if payload.metadata is not None:
+        msg.meta = payload.metadata
+    if payload.attachments is not None:
+        msg.attachments = payload.attachments
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+@router.delete("/messages/{message_id}")
+def delete_message(message_id: int, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Delete a message."""
+    msg = db.query(Message).get(message_id)
+    if not msg:
+        raise HTTPException(status_code=404, detail="not found")
+    db.delete(msg)
+    db.commit()
+    return {"status": "deleted"}
+
+
+class TaskCreate(BaseModel):
+    title: str
+    description: Optional[str] = None
+    status: str = "open"
+    assigned_to: str
+    created_by: str
+    due_date: Optional[datetime] = None
+    parent_task: Optional[int] = None
+    thread_id: Optional[int] = None
+    priority: Optional[int] = 0
+    tags: List[str] = []
+
+
+class TaskUpdate(BaseModel):
+    status: Optional[str] = None
+    description: Optional[str] = None
+    title: Optional[str] = None
+    assigned_to: Optional[str] = None
+    due_date: Optional[datetime] = None
+    priority: Optional[int] = None
+    tags: Optional[List[str]] = None
+
+
+@router.post("/tasks")
+def create_task(payload: TaskCreate, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Create a task."""
+    task = Task(**payload.dict())
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return {"id": task.id}
+
+
+@router.get("/tasks")
+def list_tasks(
+    assigned_to: str | None = None,
+    status: str | None = None,
+    thread: int | None = None,
+    db: Session = Depends(get_db),
+    _: str = Depends(get_identity),
+):
+    """List tasks filtered by assigned user, status or thread."""
+    query = db.query(Task)
+    if assigned_to is not None:
+        query = query.filter(Task.assigned_to == assigned_to)
+    if status is not None:
+        query = query.filter(Task.status == status)
+    if thread is not None:
+        query = query.filter(Task.thread_id == thread)
+    return query.all()
+
+
+@router.patch("/tasks/{task_id}")
+def update_task(task_id: int, payload: TaskUpdate, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Update task fields."""
+    task = db.query(Task).get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="not found")
+    for field, value in payload.dict(exclude_unset=True).items():
+        setattr(task, field, value)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@router.delete("/tasks/{task_id}")
+def delete_task(task_id: int, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Delete a task."""
+    task = db.query(Task).get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="not found")
+    db.delete(task)
+    db.commit()
+    return {"status": "deleted"}
+
+
+class FileMeta(BaseModel):
+    uploader: str
+    thread_id: Optional[int] = None
+    task_id: Optional[int] = None
+    metadata: Optional[dict] = None
+
+
+@router.post("/files")
+async def upload_file(
+    uploader: str = Form(...),
+    thread_id: int | None = Form(None),
+    task_id: int | None = Form(None),
+    metadata: str | None = Form(None),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    _: str = Depends(get_identity),
+):
+    """Upload a file and store metadata."""
+    dest = Path("uploads")
+    dest.mkdir(exist_ok=True)
+    path = dest / file.filename
+    with path.open("wb") as f:
+        f.write(await file.read())
+    db_file = DBFile(
+        filename=file.filename,
+        uploader=uploader,
+        path=str(path),
+        thread_id=thread_id,
+        task_id=task_id,
+        meta=json.loads(metadata) if metadata else {},
+    )
+    db.add(db_file)
+    db.commit()
+    db.refresh(db_file)
+    return {"id": db_file.id}
+
+
+@router.get("/files")
+def list_files(
+    thread: int | None = None,
+    task: int | None = None,
+    db: Session = Depends(get_db),
+    _: str = Depends(get_identity),
+):
+    """List uploaded files filtered by thread or task."""
+    query = db.query(DBFile)
+    if thread is not None:
+        query = query.filter(DBFile.thread_id == thread)
+    if task is not None:
+        query = query.filter(DBFile.task_id == task)
+    return query.all()
+
+
+@router.delete("/files/{file_id}")
+def delete_file(file_id: int, db: Session = Depends(get_db), _: str = Depends(get_identity)):
+    """Delete a stored file and remove from disk."""
+    db_file = db.query(DBFile).get(file_id)
+    if not db_file:
+        raise HTTPException(status_code=404, detail="not found")
+    path = Path(db_file.path)
+    if path.exists():
+        try:
+            path.unlink()
+        except Exception:
+            pass
+    db.delete(db_file)
+    db.commit()
+    return {"status": "deleted"}
+

--- a/db/models.py
+++ b/db/models.py
@@ -44,7 +44,7 @@ class Thread(Base):
 
     id = Column(Integer, primary_key=True)
     title = Column(String(255))
-    participants = Column(ARRAY(String))
+    participants = Column(JSON)
     project_id = Column(String(255), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -61,7 +61,7 @@ class Message(Base):
     recipient = Column(String(50), nullable=True)
     content = Column(Text)
     created_at = Column(DateTime, default=datetime.utcnow)
-    metadata = Column(JSON)
+    meta = Column('metadata', JSON)
     attachments = Column(JSON, nullable=True)
 
     thread = relationship("Thread", back_populates="messages")
@@ -80,7 +80,7 @@ class Task(Base):
     parent_task = Column(Integer, ForeignKey("tasks.id"), nullable=True)
     thread_id = Column(Integer, ForeignKey("threads.id"), nullable=True)
     priority = Column(Integer)
-    tags = Column(ARRAY(String))
+    tags = Column(JSON)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -99,7 +99,7 @@ class File(Base):
     thread_id = Column(Integer, ForeignKey("threads.id"), nullable=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
-    metadata = Column(JSON)
+    meta = Column('metadata', JSON)
 
     thread = relationship("Thread")
     task = relationship("Task", back_populates="files")

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from codex.memory import memory_store, agent_inbox
 from codex.integrations.make_webhook import router as make_webhook_router
 from codex.memory.memory_api import router as memory_api_router
 from codex.ai.gemini_webhook import router as gemini_webhook_router
+from chat_task_api import router as chat_task_router
 import codex.ai.claude_sync as claude_sync
 from utils.ai_router import get_ai_model
 
@@ -107,6 +108,7 @@ app = FastAPI(lifespan=lifespan, dependencies=[Depends(get_current_user)])
 app.include_router(make_webhook_router)
 app.include_router(memory_api_router)
 app.include_router(gemini_webhook_router)
+app.include_router(chat_task_router)
 
 # Serve dashboard with authentication
 dashboard_app = FastAPI(dependencies=[Depends(get_current_user)])

--- a/tests/test_chat_task_api.py
+++ b/tests/test_chat_task_api.py
@@ -1,0 +1,97 @@
+import os
+import importlib
+from io import BytesIO
+from fastapi.testclient import TestClient
+
+os.environ["AGENT_KEYS"] = '{"agent":"secret"}'
+os.environ.pop("BASIC_AUTH_USERS", None)
+os.environ.pop("ADMIN_USERS", None)
+os.environ.setdefault("SUPABASE_URL", "http://example.com")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+os.environ.setdefault("FERNET_SECRET", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
+
+import chat_task_api
+importlib.reload(chat_task_api)
+import main as main_module
+importlib.reload(main_module)
+
+def get_client():
+    os.environ.pop("BASIC_AUTH_USERS", None)
+    os.environ.pop("ADMIN_USERS", None)
+    os.environ["AGENT_KEYS"] = '{"agent":"secret"}'
+    importlib.reload(chat_task_api)
+    importlib.reload(main_module)
+    return TestClient(main_module.app)
+
+headers = {"X-Agent-Key": "secret"}
+
+
+def test_thread_and_message_lifecycle():
+    client = get_client()
+    t_resp = client.post("/threads", json={"title": "Test"}, headers=headers)
+    assert t_resp.status_code == 200
+    thread_id = t_resp.json()["id"]
+
+    m_resp = client.post(
+        "/messages",
+        json={"thread_id": thread_id, "sender": "me", "content": "hi"},
+        headers=headers,
+    )
+    assert m_resp.status_code == 200
+    msg_id = m_resp.json()["id"]
+
+    list_resp = client.get(f"/messages?thread={thread_id}", headers=headers)
+    assert list_resp.status_code == 200
+    assert any(m["id"] == msg_id for m in list_resp.json())
+
+    patch = client.patch(
+        f"/messages/{msg_id}", json={"content": "edited"}, headers=headers
+    )
+    assert patch.status_code == 200
+    del_resp = client.delete(f"/messages/{msg_id}", headers=headers)
+    assert del_resp.status_code == 200
+
+
+def test_task_and_file_endpoints():
+    client = get_client()
+    t_resp = client.post("/threads", json={"title": "TaskThread"}, headers=headers)
+    thread_id = t_resp.json()["id"]
+    task_resp = client.post(
+        "/tasks",
+        json={
+            "title": "Do",
+            "description": "d",
+            "assigned_to": "a",
+            "created_by": "a",
+            "thread_id": thread_id,
+        },
+        headers=headers,
+    )
+    assert task_resp.status_code == 200
+    task_id = task_resp.json()["id"]
+
+    list_resp = client.get(f"/tasks?thread={thread_id}", headers=headers)
+    assert any(t["id"] == task_id for t in list_resp.json())
+
+    upd = client.patch(
+        f"/tasks/{task_id}", json={"status": "done"}, headers=headers
+    )
+    assert upd.status_code == 200
+
+    file_resp = client.post(
+        "/files",
+        headers=headers,
+        data={"uploader": "me", "thread_id": str(thread_id)},
+        files={"file": ("test.txt", BytesIO(b"data"), "text/plain")},
+    )
+    assert file_resp.status_code == 200
+    file_id = file_resp.json()["id"]
+
+    list_files = client.get(f"/files?thread={thread_id}", headers=headers)
+    assert any(f["id"] == file_id for f in list_files.json())
+
+    del_file = client.delete(f"/files/{file_id}", headers=headers)
+    assert del_file.status_code == 200
+    del_task = client.delete(f"/tasks/{task_id}", headers=headers)
+    assert del_task.status_code == 200
+


### PR DESCRIPTION
## Summary
- add new REST router `chat_task_api.py` for chat messages, threads, tasks and file uploads
- include `chat_task_router` in FastAPI app
- update DB models for compatibility with SQLite
- add authentication helper for agent keys
- implement unittests covering thread/message/task/file endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed8e867f083239ff1c1195b1fafd9