### PR TITLE
Add marketing pages and contact route

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ The dashboard at `/dashboard/ui` includes a PWA manifest. Open the page in a mod
 
 A production-ready dashboard is located in `dashboard_ui/` built with Next.js, Tailwind CSS and shadcn/ui components. It can be deployed statically or embedded via `<iframe>`.
 
+## Marketing Site
+
+The same Next.js project also hosts a lightweight marketing site for BrainStack Studio. Visit `/`, `/products`, `/about`, `/contact` or `/blog` for the public pages. The contact form submits to `/api/contact` and forwards data to the `MAKE_WEBHOOK_URL` if set.
+
 ### Build & Export
 
 ```bash
@@ -130,6 +134,7 @@ The same snippet works in Tana, Google Sites or any platform that allows iframes
 
 - API endpoint base URL is configured with `NEXT_PUBLIC_API_BASE`.
 - Set `NEXT_PUBLIC_AUTH_HEADER` if your FastAPI server requires HTTP Basic or JWT auth (e.g. `"Basic dXNlcjpwYXNz"` or `"Bearer <token>").
+- Optional `MAKE_WEBHOOK_URL` is used by the contact form to forward submissions.
 - Branding and styling can be tweaked in `dashboard_ui/styles` and React components.
 
 ### BrainOps AI Assistant

--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,16 @@
+export const metadata = { title: 'About' };
+
+export default function AboutPage() {
+  return (
+    <div className="space-y-4 max-w-2xl">
+      <h2 className="text-3xl font-semibold">About BrainStack Studio</h2>
+      <p>BrainStack Studio builds the BrainOps design system and automation templates to help teams launch faster.</p>
+      <p>Our small but mighty team is passionate about empowering builders to operate intelligently.</p>
+      <ul className="list-disc pl-6 space-y-1">
+        <li><strong>Ash Ketchum</strong> – Founder & Strategy</li>
+        <li><strong>Misty Waters</strong> – Product & Ops</li>
+        <li><strong>Brock Stone</strong> – Engineering Lead</li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/app/api/contact/route.ts
+++ b/frontend/app/api/contact/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { name, email, message } = await req.json();
+  if (!name || !email || !message) {
+    return NextResponse.json({ error: 'missing fields' }, { status: 400 });
+  }
+  const webhook = process.env.MAKE_WEBHOOK_URL;
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, message }),
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { marked } from 'marked';
+
+export const metadata = { title: 'Blog' };
+
+export default function BlogPage() {
+  const postsDir = path.join(process.cwd(), 'dashboard_ui/data/posts');
+  const files = fs.readdirSync(postsDir);
+  const posts = files.map((file) => {
+    const md = fs.readFileSync(path.join(postsDir, file), 'utf8');
+    const html = marked(md);
+    return { slug: file.replace(/\.md$/, ''), html };
+  });
+
+  return (
+    <div className="space-y-8">
+      <h2 className="text-3xl font-semibold">Blog</h2>
+      {posts.map((p) => (
+        <article key={p.slug} className="prose" dangerouslySetInnerHTML={{ __html: p.html }} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useState } from 'react';
+
+export const metadata = { title: 'Contact' };
+
+export default function ContactPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus('sending');
+    const res = await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, message }),
+    });
+    if (res.ok) {
+      setStatus('sent');
+      setName('');
+      setEmail('');
+      setMessage('');
+    } else {
+      setStatus('error');
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto space-y-4">
+      <h2 className="text-3xl font-semibold">Contact Us</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input className="w-full border p-2" placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
+        <input className="w-full border p-2" type="email" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <textarea className="w-full border p-2" rows={5} placeholder="Message" value={message} onChange={e => setMessage(e.target.value)} />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">Send</button>
+      </form>
+      {status === 'sent' && <p className='text-green-600'>Thanks! We\'ll be in touch.</p>}
+      {status === 'error' && <p className='text-red-600'>Something went wrong.</p>}
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,29 @@
+import '../styles/globals.css';
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'BrainStack Studio',
+  description: 'BrainOps templates, guides and automation tools',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const year = new Date().getFullYear();
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex flex-col">
+        <header className="flex justify-between items-center p-4 border-b">
+          <Link href="/" className="font-bold text-xl">BrainStackStudio</Link>
+          <nav className="space-x-4">
+            <Link href="/products">Products</Link>
+            <Link href="/about">About</Link>
+            <Link href="/blog">Blog</Link>
+            <Link href="/contact">Contact</Link>
+            <Link href="/dashboard" className="font-semibold">Dashboard</Link>
+          </nav>
+        </header>
+        <main className="flex-1 p-4">{children}</main>
+        <footer className="border-t p-4 text-center text-sm">&copy; {year} BrainStackStudio</footer>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <section className="text-center py-20 space-y-6">
+      <motion.h2 initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6 }} className="text-4xl font-bold">
+        Launch Smarter with BrainStack Studio
+      </motion.h2>
+      <p className="max-w-xl mx-auto text-lg">
+        Build, operate and grow your products using our BrainOps design system and automation templates.
+      </p>
+      <div className="flex justify-center gap-4">
+        <Link href="/products" className="bg-blue-600 text-white px-6 py-3 rounded">Explore Templates</Link>
+        <Link href="/contact" className="border border-blue-600 text-blue-600 px-6 py-3 rounded">Get In Touch</Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -1,0 +1,21 @@
+import products from '../../data/products.json';
+import Link from 'next/link';
+
+export const metadata = { title: 'Products' };
+
+export default function ProductsPage() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-3xl font-semibold">Products</h2>
+      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {products.map((p) => (
+          <li key={p.id} className="border rounded-lg p-4 flex flex-col">
+            <h3 className="text-lg font-semibold mb-2">{p.title}</h3>
+            <p className="flex-1">{p.description}</p>
+            <Link href={p.link} className="mt-4 underline text-blue-600">{p.cta || 'Learn more'}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/data/posts/automation.md
+++ b/frontend/data/posts/automation.md
@@ -1,0 +1,3 @@
+# Automation Tips
+
+Learn how to streamline your operations with these quick BrainOps automation tips.

--- a/frontend/data/posts/welcome.md
+++ b/frontend/data/posts/welcome.md
@@ -1,0 +1,3 @@
+# Welcome to BrainStack Studio
+
+We're excited to launch BrainStack Studio. This space will share updates on new templates, automation guides and our approach to BrainOps.

--- a/frontend/data/products.json
+++ b/frontend/data/products.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "brainops-starter",
+    "title": "BrainOps Starter Kit",
+    "description": "Essential playbooks and setup guides for new teams.",
+    "link": "#",
+    "cta": "Buy Now"
+  },
+  {
+    "id": "growth-playbook",
+    "title": "Growth Automation Playbook",
+    "description": "Automated workflows to scale your marketing and analytics.",
+    "link": "#",
+    "cta": "Purchase"
+  },
+  {
+    "id": "ai-stack-guides",
+    "title": "AI Stack Guides",
+    "description": "Integrate AI capabilities into your product with minimal effort.",
+    "link": "#",
+    "cta": "Learn More"
+  }
+]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build", 
+    "build": "next build",
     "start": "next start"
   },
   "dependencies": {
@@ -18,7 +18,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.7.2",
-    "tailwindcss": "^3.4.5"
+    "tailwindcss": "^3.4.5",
+    "marked": "^9.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.29",

--- a/logs/task_log.json
+++ b/logs/task_log.json
@@ -1,1 +1,291 @@
-[]
+[
+  {
+    "id": "21c88058-7891-4321-aaeb-0614d6877439",
+    "timestamp": "2025-07-10T00:24:49.810545+00:00",
+    "task": "claude_calendar_planner",
+    "context": {},
+    "result": {
+      "plan": "",
+      "executed_by": "claude"
+    },
+    "retry": 0
+  },
+  {
+    "id": "2efe5633-f9f3-46db-af47-9983d77a9d83",
+    "timestamp": "2025-07-10T00:24:50.498630+00:00",
+    "task": "inbox_prioritizer",
+    "context": {},
+    "result": {
+      "prioritized": "",
+      "executed_by": "claude"
+    },
+    "retry": 0
+  },
+  {
+    "id": "d0ebc8a0-5b00-4746-b53a-ec5432db3228",
+    "timestamp": "2025-07-10T00:24:51.989555+00:00",
+    "task": "memory_sync_agent",
+    "context": {},
+    "result": {
+      "summary": "",
+      "executed_by": "claude"
+    },
+    "retry": 0
+  },
+  {
+    "id": "8fccac8c-92dd-43b1-a722-a0c22dd4b914",
+    "timestamp": "2025-07-10T00:24:52.831296+00:00",
+    "task": "ai_coauthored_composer",
+    "context": {
+      "intent": "test"
+    },
+    "result": {
+      "plan": {
+        "tasks": []
+      },
+      "metadata": {
+        "authors": [
+          "claude",
+          "gemini"
+        ],
+        "version": "1.0",
+        "model": "claude"
+      },
+      "executed_by": "claude"
+    },
+    "retry": 0
+  },
+  {
+    "id": "5a51598a-2b64-4312-99ad-2fab6a14426b",
+    "timestamp": "2025-07-10T00:24:53.494806+00:00",
+    "task": "workflow_audit_agent",
+    "context": {},
+    "result": {
+      "issues": "",
+      "patches": ""
+    },
+    "retry": 0
+  },
+  {
+    "id": "eae51802-8ef3-47be-af64-b8fe81cc0138",
+    "timestamp": "2025-07-10T00:24:54.016271+00:00",
+    "task": "memory_diff_checker",
+    "context": {
+      "task_id": "claude_prompt"
+    },
+    "result": {
+      "claude": false,
+      "gemini": false,
+      "discrepancy": false
+    },
+    "retry": 0
+  },
+  {
+    "id": "65109e58-4d68-48e3-833b-ce420576db33",
+    "timestamp": "2025-07-10T00:24:54.572510+00:00",
+    "task": "strategy_forecaster",
+    "context": {
+      "goal": "Optimize AI pipeline delivery over the next 7 days"
+    },
+    "result": {
+      "schedule_by_day": {
+        "Monday": [
+          "sample_task"
+        ],
+        "Tuesday": [
+          "sample_task"
+        ],
+        "Wednesday": [
+          "sample_task"
+        ],
+        "Thursday": [
+          "sample_task"
+        ],
+        "Friday": [
+          "sample_task"
+        ],
+        "Saturday": [
+          "sample_task"
+        ],
+        "Sunday": [
+          "sample_task"
+        ]
+      },
+      "tasks": [
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        },
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        },
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        },
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        },
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        },
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        },
+        {
+          "task": "sample_task",
+          "urgency": "medium"
+        }
+      ],
+      "route_map": [
+        {
+          "task": "sample_task",
+          "model": "claude"
+        },
+        {
+          "task": "sample_task",
+          "model": "claude"
+        },
+        {
+          "task": "sample_task",
+          "model": "claude"
+        },
+        {
+          "task": "sample_task",
+          "model": "claude"
+        },
+        {
+          "task": "sample_task",
+          "model": "claude"
+        },
+        {
+          "task": "sample_task",
+          "model": "claude"
+        },
+        {
+          "task": "sample_task",
+          "model": "claude"
+        }
+      ],
+      "executed_by": "claude"
+    },
+    "retry": 0
+  },
+  {
+    "id": "34cf28e9-b990-4d02-9060-f482096920f6",
+    "timestamp": "2025-07-10T00:24:55.012023+00:00",
+    "task": "timeline_builder",
+    "context": {},
+    "result": {
+      "timeline": {
+        "Monday": [
+          "sample_task"
+        ],
+        "Tuesday": [
+          "sample_task"
+        ],
+        "Wednesday": [
+          "sample_task"
+        ],
+        "Thursday": [
+          "sample_task"
+        ],
+        "Friday": [
+          "sample_task"
+        ],
+        "Saturday": [
+          "sample_task"
+        ],
+        "Sunday": [
+          "sample_task"
+        ]
+      }
+    },
+    "retry": 0
+  },
+  {
+    "id": "1c2a4587-47c6-4c28-9f9e-0e47183ad225",
+    "timestamp": "2025-07-10T00:24:55.510285+00:00",
+    "task": "claude_strategy_agent",
+    "context": {},
+    "result": {
+      "goals": [
+        "Goal 1",
+        "Goal 2",
+        "Goal 3"
+      ],
+      "recommended_tasks": [
+        {
+          "task": "task_1",
+          "context": {}
+        },
+        {
+          "task": "task_2",
+          "context": {}
+        },
+        {
+          "task": "task_3",
+          "context": {}
+        }
+      ]
+    },
+    "retry": 0
+  },
+  {
+    "id": "8512ea2c-240e-4119-b4fd-9a5e1ab51bc1",
+    "timestamp": "2025-07-10T00:24:55.861900+00:00",
+    "task": "gemini_dependency_map",
+    "context": {
+      "tasks": [
+        {
+          "task": "A"
+        },
+        {
+          "task": "B",
+          "depends_on": "A"
+        }
+      ]
+    },
+    "result": {
+      "dependency_order": [
+        "A",
+        "B"
+      ],
+      "map": [
+        {
+          "task": "A",
+          "depends_on": null
+        },
+        {
+          "task": "B",
+          "depends_on": "A"
+        }
+      ]
+    },
+    "retry": 0
+  },
+  {
+    "id": "36d7c600-0db3-4ec8-9d66-a909895bf8ef",
+    "timestamp": "2025-07-10T00:24:56.227569+00:00",
+    "task": "unified_rag_agent",
+    "context": {
+      "query": "Claude recommended",
+      "sources": [
+        "local_docs"
+      ],
+      "model": null
+    },
+    "result": {
+      "summary": "",
+      "sources": [
+        "data/docs/weekly_plan.md"
+      ],
+      "model": null
+    },
+    "retry": 0
+  }
+]

--- a/tests/test_chat_task_api.py
+++ b/tests/test_chat_task_api.py
@@ -21,6 +21,8 @@ def get_client():
     os.environ["AGENT_KEYS"] = '{"agent":"secret"}'
     importlib.reload(chat_task_api)
     importlib.reload(main_module)
+    import db.session
+    db.session.init_db()
     return TestClient(main_module.app)
 
 headers = {"X-Agent-Key": "secret"}


### PR DESCRIPTION
## Summary
- scaffold BrainStack Studio marketing site inside dashboard UI
- add landing, products, about, blog and contact pages
- wire up contact form API route
- parse markdown posts at build time
- document marketing site setup and `MAKE_WEBHOOK_URL`
- fix tests by initializing DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f05c267ec8323ae28b316f4528035