### PR TITLE
Add Ops dashboard

### DIFF
--- a/data/ops_data.json
+++ b/data/ops_data.json
@@ -1,0 +1,9 @@
+{
+  "sales": 1200,
+  "signups": 50,
+  "active_users": 20,
+  "product_kpis": {
+    "blog_posts": 5,
+    "newsletters": 3
+  }
+}

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -15,6 +15,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         <nav className="space-y-2">
           <Link href="/dashboard" className="block">Home</Link>
           <Link href="/dashboard/memory" className="block">Memory</Link>
+          <Link href="/dashboard/ops" className="block">Ops</Link>
           <Link href="/dashboard/copilot" className="block">Copilot</Link>
           <Link href="/dashboard/copilot-v2" className="block">Copilot v2</Link>
           <Link href="/dashboard/sync" className="block">Sync</Link>

--- a/frontend/app/dashboard/ops/page.tsx
+++ b/frontend/app/dashboard/ops/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { fetchOpsMetrics } from '../../../utils/api';
+
+export default function OpsPage() {
+  const [metrics, setMetrics] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchOpsMetrics();
+        setMetrics(data);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Operations Dashboard</h2>
+      {loading && <p>Loading...</p>}
+      {metrics && (
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div className="border rounded p-4 text-center">
+            <p className="text-sm opacity-70">Sales</p>
+            <p className="text-2xl font-semibold">{metrics.sales ?? 0}</p>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <p className="text-sm opacity-70">Signups</p>
+            <p className="text-2xl font-semibold">{metrics.signups ?? 0}</p>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <p className="text-sm opacity-70">Active Users</p>
+            <p className="text-2xl font-semibold">{metrics.active_users ?? 0}</p>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <p className="text-sm opacity-70">Tasks Logged</p>
+            <p className="text-2xl font-semibold">{metrics.tasks_logged ?? 0}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -41,3 +41,7 @@ export async function writeMemory(entry: {
 export async function fetchProductDocs() {
   return fetch(`${API_BASE}/memory/query?tags=product&limit=50`).then(r => r.json());
 }
+
+export async function fetchOpsMetrics() {
+  return fetch(`${API_BASE}/dashboard/ops`).then(r => r.json());
+}

--- a/main.py
+++ b/main.py
@@ -931,6 +931,23 @@ async def dashboard_sync() -> Dict[str, Any]:
     }
 
 
+@app.get("/dashboard/ops")
+async def dashboard_ops() -> Dict[str, Any]:
+    """Combined operations metrics including sales and signups."""
+    metrics = await dashboard_metrics()
+    tasks = await dashboard_tasks()
+    status = await dashboard_status()
+    data_file = Path("data/ops_data.json")
+    extra: Dict[str, Any] = {}
+    if data_file.exists():
+        try:
+            extra = json.loads(data_file.read_text())
+        except Exception:  # noqa: BLE001
+            extra = {}
+    result = {**status, **metrics, **tasks, **extra}
+    return result
+
+
 @app.get("/diagnostics/state")
 async def diagnostics_state() -> Dict[str, Any]:
     active_tasks = 0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -147,6 +147,12 @@ def test_dashboard_metrics():
     assert 'tasks_logged' in data
 
 
+def test_dashboard_ops():
+    resp = client.get('/dashboard/ops')
+    assert resp.status_code == 200
+    assert 'sales' in resp.json()
+
+
 def test_search_and_error_logs():
     resp = client.get('/memory/search?q=test')
     assert resp.status_code == 200

--- a/tests/test_dashboard_components.py
+++ b/tests/test_dashboard_components.py
@@ -33,3 +33,8 @@ def test_pipeline_component_exists():
 def test_products_page_exists():
     path = pathlib.Path('dashboard_ui/app/dashboard/products/page.tsx')
     assert path.exists()
+
+
+def test_ops_page_exists():
+    path = pathlib.Path('dashboard_ui/app/dashboard/ops/page.tsx')
+    assert path.exists()


### PR DESCRIPTION
## Summary
- add combined `/dashboard/ops` API endpoint
- provide sample metrics in `data/ops_data.json`
- expose new Ops page in dashboard
- update frontend API helpers and navigation
- test new page and endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0c6441bc83239716136e74c45edd