### PR TITLE
Add ClickUp/Notion CRUD endpoints

### DIFF
--- a/codex/integrations/clickup.py
+++ b/codex/integrations/clickup.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Dict, Any, List
+import time
+from typing import Dict, Any, List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
 
 import httpx
 
@@ -16,39 +20,152 @@ _TOKEN = os.getenv("CLICKUP_API_TOKEN")
 _headers = {"Authorization": _TOKEN} if _TOKEN else {}
 
 
-def create_task(title: str, description: str, list_id: str) -> Dict[str, Any]:
-    """Create a task in ClickUp.
+def _request(
+    method: str,
+    url: str,
+    token: str,
+    idempotency_key: str | None = None,
+    **kwargs: Any,
+) -> dict:
+    """HTTP request with exponential backoff."""
+    headers = kwargs.pop("headers", {})
+    if token:
+        headers.setdefault("Authorization", token)
+    if idempotency_key:
+        headers.setdefault("Idempotency-Key", idempotency_key)
 
-    Returns the API response JSON or ``{"error": "message"}`` on failure or when
-    authentication is missing.
-    """
-    if not _TOKEN:
-        return {"error": "not_configured"}
+    backoff = 1.0
+    for attempt in range(3):
+        try:  # pragma: no cover - network
+            resp = httpx.request(method, url, headers=headers, timeout=10, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # noqa: BLE001
+            if attempt == 2:
+                logger.error("ClickUp request failed: %s", exc)
+                raise
+            time.sleep(backoff)
+            backoff *= 2
+
+
+def create_task(
+    workspace: str,
+    token: str,
+    list_id: str,
+    title: str,
+    description: str,
+    idempotency_key: str | None = None,
+) -> Dict[str, Any]:
+    """Create a task in ClickUp."""
+
+    url = f"{_API_BASE}/list/{list_id}/task"
     payload = {"name": title, "description": description}
-    try:  # pragma: no cover - external network
-        resp = httpx.post(
-            f"{_API_BASE}/list/{list_id}/task",
-            json=payload,
-            headers=_headers,
-            timeout=10,
-        )
-        resp.raise_for_status()
-        return resp.json()
-    except Exception as exc:  # noqa: BLE001
-        logger.error("ClickUp create_task failed: %s", exc)
-        return {"error": str(exc)}
+    return _request("POST", url, token, idempotency_key, json=payload)
 
 
-def search_tasks(query: str) -> List[Dict[str, Any]]:
+def get_task(workspace: str, token: str, task_id: str) -> Dict[str, Any]:
+    """Fetch a single task."""
+
+    url = f"{_API_BASE}/task/{task_id}"
+    return _request("GET", url, token)
+
+
+def update_task(
+    workspace: str,
+    token: str,
+    task_id: str,
+    data: Dict[str, Any],
+    idempotency_key: str | None = None,
+) -> Dict[str, Any]:
+    """Update a ClickUp task."""
+
+    url = f"{_API_BASE}/task/{task_id}"
+    return _request("PUT", url, token, idempotency_key, json=data)
+
+
+def delete_task(workspace: str, token: str, task_id: str) -> Dict[str, Any]:
+    """Delete a task."""
+
+    url = f"{_API_BASE}/task/{task_id}"
+    return _request("DELETE", url, token)
+
+
+def search_tasks(workspace: str, token: str, query: str) -> List[Dict[str, Any]]:
     """Search tasks in ClickUp matching ``query`` text."""
-    if not _TOKEN:
-        return []
+
     params = {"query": query}
-    try:  # pragma: no cover - external network
-        resp = httpx.get(f"{_API_BASE}/task", params=params, headers=_headers, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
+    try:  # pragma: no cover - network
+        data = _request("GET", f"{_API_BASE}/task", token, params=params)
         return data.get("tasks", [])
     except Exception as exc:  # noqa: BLE001
         logger.error("ClickUp search failed: %s", exc)
         return []
+
+
+def handle_webhook(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Process ClickUp webhook payload."""
+
+    logger.info("Received ClickUp webhook: %s", event)
+    return {"status": "received"}
+
+
+router = APIRouter(prefix="/clickup")
+
+
+class TaskPayload(BaseModel):
+    list_id: str
+    title: str
+    description: str
+    token: str
+    workspace: str
+    idempotency_key: Optional[str] = None
+
+
+@router.post("/tasks")
+def api_create_task(payload: TaskPayload) -> Dict[str, Any]:
+    return create_task(
+        payload.workspace,
+        payload.token,
+        payload.list_id,
+        payload.title,
+        payload.description,
+        payload.idempotency_key,
+    )
+
+
+@router.get("/tasks/{task_id}")
+def api_get_task(task_id: str, token: str, workspace: str) -> Dict[str, Any]:
+    return get_task(workspace, token, task_id)
+
+
+class UpdatePayload(BaseModel):
+    token: str
+    workspace: str
+    fields: Dict[str, Any]
+    idempotency_key: Optional[str] = None
+
+
+@router.put("/tasks/{task_id}")
+def api_update_task(task_id: str, payload: UpdatePayload) -> Dict[str, Any]:
+    return update_task(
+        payload.workspace,
+        payload.token,
+        task_id,
+        payload.fields,
+        payload.idempotency_key,
+    )
+
+
+@router.delete("/tasks/{task_id}")
+def api_delete_task(task_id: str, token: str, workspace: str) -> Dict[str, Any]:
+    return delete_task(workspace, token, task_id)
+
+
+@router.get("/tasks/search")
+def api_search_tasks(token: str, workspace: str, query: str) -> List[Dict[str, Any]]:
+    return search_tasks(workspace, token, query)
+
+
+@router.post("/webhook")
+def api_webhook(event: Dict[str, Any]):
+    return handle_webhook(event)

--- a/codex/integrations/notion.py
+++ b/codex/integrations/notion.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List, Dict
+import time
+from typing import List, Dict, Any, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
 
 import httpx
 
@@ -16,6 +20,35 @@ _VERSION = "2022-06-28"
 _TOKEN = os.getenv("NOTION_API_KEY")
 
 
+
+def _request(
+    method: str,
+    url: str,
+    token: str,
+    idempotency_key: str | None = None,
+    **kwargs: Any,
+) -> dict:
+    headers = kwargs.pop("headers", {})
+    if token:
+        headers.setdefault("Authorization", f"Bearer {token}")
+    headers.setdefault("Notion-Version", _VERSION)
+    if idempotency_key:
+        headers.setdefault("Idempotency-Key", idempotency_key)
+
+    backoff = 1.0
+    for attempt in range(3):
+        try:  # pragma: no cover - network
+            resp = httpx.request(method, url, headers=headers, timeout=10, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # noqa: BLE001
+            if attempt == 2:
+                logger.error("Notion request failed: %s", exc)
+                raise
+            time.sleep(backoff)
+            backoff *= 2
+
+
 def _headers() -> dict:
     if not _TOKEN:
         return {}
@@ -25,19 +58,15 @@ def _headers() -> dict:
     }
 
 
-def search_notion_pages(query: str) -> List[Dict[str, str]]:
+def search_notion_pages(workspace: str, token: str, query: str) -> List[Dict[str, str]]:
     """Search Notion workspace pages by text query.
 
     Returns a list of page ``{"id": str, "title": str}`` dictionaries. If the
     token is missing or the request fails, an empty list is returned.
     """
-    if not _TOKEN:
-        return []
     payload = {"query": query, "sort": {"direction": "descending", "timestamp": "last_edited_time"}}
-    try:  # pragma: no cover - external network
-        resp = httpx.post(f"{_API_BASE}/search", json=payload, headers=_headers(), timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
+    try:  # pragma: no cover - network
+        data = _request("POST", f"{_API_BASE}/search", token, json=payload)
     except Exception as exc:  # noqa: BLE001
         logger.error("Notion search failed: %s", exc)
         return []
@@ -55,19 +84,124 @@ def search_notion_pages(query: str) -> List[Dict[str, str]]:
     return results
 
 
-def get_page_snippet(page_id: str) -> str:
+def create_page(
+    workspace: str,
+    token: str,
+    parent_id: str,
+    title: str,
+    properties: Dict[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> Dict[str, Any]:
+    payload = {
+        "parent": {"page_id": parent_id},
+        "properties": properties or {"title": [{"text": {"content": title}}]},
+    }
+    return _request("POST", f"{_API_BASE}/pages", token, idempotency_key, json=payload)
+
+
+def get_page(workspace: str, token: str, page_id: str) -> Dict[str, Any]:
+    return _request("GET", f"{_API_BASE}/pages/{page_id}", token)
+
+
+def update_page(
+    workspace: str,
+    token: str,
+    page_id: str,
+    properties: Dict[str, Any],
+    idempotency_key: str | None = None,
+) -> Dict[str, Any]:
+    payload = {"properties": properties}
+    return _request("PATCH", f"{_API_BASE}/pages/{page_id}", token, idempotency_key, json=payload)
+
+
+def delete_page(workspace: str, token: str, page_id: str) -> Dict[str, Any]:
+    payload = {"archived": True}
+    return _request("PATCH", f"{_API_BASE}/pages/{page_id}", token, json=payload)
+
+
+def handle_webhook(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Process Notion webhook payload."""
+
+    logger.info("Received Notion webhook: %s", event)
+    return {"status": "received"}
+
+
+router = APIRouter(prefix="/notion")
+
+
+class PageCreatePayload(BaseModel):
+    parent_id: str
+    title: str
+    token: str
+    workspace: str
+    properties: Optional[Dict[str, Any]] = None
+    idempotency_key: Optional[str] = None
+
+
+@router.post("/pages")
+def api_create_page(payload: PageCreatePayload) -> Dict[str, Any]:
+    return create_page(
+        payload.workspace,
+        payload.token,
+        payload.parent_id,
+        payload.title,
+        payload.properties,
+        payload.idempotency_key,
+    )
+
+
+@router.get("/pages/{page_id}")
+def api_get_page(page_id: str, token: str, workspace: str) -> Dict[str, Any]:
+    return get_page(workspace, token, page_id)
+
+
+class PageUpdatePayload(BaseModel):
+    token: str
+    workspace: str
+    properties: Dict[str, Any]
+    idempotency_key: Optional[str] = None
+
+
+@router.patch("/pages/{page_id}")
+def api_update_page(page_id: str, payload: PageUpdatePayload) -> Dict[str, Any]:
+    return update_page(
+        payload.workspace,
+        payload.token,
+        page_id,
+        payload.properties,
+        payload.idempotency_key,
+    )
+
+
+@router.delete("/pages/{page_id}")
+def api_delete_page(page_id: str, token: str, workspace: str) -> Dict[str, Any]:
+    return delete_page(workspace, token, page_id)
+
+
+@router.get("/pages/search")
+def api_search_pages(token: str, workspace: str, query: str) -> List[Dict[str, str]]:
+    return search_notion_pages(workspace, token, query)
+
+
+@router.get("/pages/{page_id}/snippet")
+def api_page_snippet(page_id: str, token: str, workspace: str) -> str:
+    return get_page_snippet(workspace, token, page_id)
+
+
+@router.post("/webhook")
+def api_webhook(event: Dict[str, Any]):
+    return handle_webhook(event)
+
+
+def get_page_snippet(workspace: str, token: str, page_id: str) -> str:
     """Return a short text snippet from the top of a Notion page."""
-    if not _TOKEN:
-        return ""
-    try:  # pragma: no cover - external network
-        resp = httpx.get(
+    try:  # pragma: no cover - network
+        data = _request(
+            "GET",
             f"{_API_BASE}/blocks/{page_id}/children",
+            token,
             params={"page_size": 5},
-            headers=_headers(),
-            timeout=10,
         )
-        resp.raise_for_status()
-        data = resp.json()
     except Exception as exc:  # noqa: BLE001
         logger.error("Notion snippet failed: %s", exc)
         return ""

--- a/main.py
+++ b/main.py
@@ -65,6 +65,8 @@ from codex import get_registry, run_task
 from celery_app import celery_app, long_task
 from codex.memory import memory_store, agent_inbox
 from codex.integrations.make_webhook import router as make_webhook_router
+from codex.integrations.clickup import router as clickup_router
+from codex.integrations.notion import router as notion_router
 from codex.memory.memory_api import router as memory_api_router
 from codex.ai.gemini_webhook import router as gemini_webhook_router
 from chat_task_api import router as chat_task_router
@@ -161,6 +163,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan, dependencies=[Depends(get_current_user)])
 app.include_router(make_webhook_router)
+app.include_router(clickup_router)
+app.include_router(notion_router)
 app.include_router(memory_api_router)
 app.include_router(gemini_webhook_router)
 app.include_router(chat_task_router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ celery
 redis
 loguru
 prometheus_client
+pytest-httpx

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,52 @@
+import os
+import importlib
+import pytest
+
+os.environ.setdefault("FERNET_SECRET", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
+os.environ.setdefault("SUPABASE_URL", "http://example.com")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("STRIPE_SECRET_KEY", "test")
+os.environ.setdefault("TANA_API_KEY", "test")
+os.environ.setdefault("VERCEL_TOKEN", "test")
+
+import codex.integrations.clickup as clickup
+import codex.integrations.notion as notion
+
+
+def test_clickup_crud(httpx_mock):
+    httpx_mock.add_response(json={"id": "1"})
+    resp = clickup.create_task("ws", "tok", "123", "t", "d", idempotency_key="abc")
+    req = httpx_mock.get_requests()[-1]
+    assert req.headers["Authorization"] == "tok"
+    assert req.headers["Idempotency-Key"] == "abc"
+    assert resp["id"] == "1"
+
+    httpx_mock.add_response(json={"id": "1"})
+    resp = clickup.get_task("ws", "tok", "1")
+    assert resp["id"] == "1"
+
+    httpx_mock.add_response(json={"status": "ok"})
+    resp = clickup.update_task("ws", "tok", "1", {"name": "new"}, idempotency_key="def")
+    req = httpx_mock.get_requests()[-1]
+    assert req.headers["Idempotency-Key"] == "def"
+    assert resp["status"] == "ok"
+
+    httpx_mock.add_response(json={"status": "deleted"})
+    resp = clickup.delete_task("ws", "tok", "1")
+    assert resp["status"] == "deleted"
+
+
+def test_notion_crud(httpx_mock):
+    httpx_mock.add_response(json={"id": "p"})
+    resp = notion.create_page("ws", "token", "parent", "title")
+    req = httpx_mock.get_requests()[-1]
+    assert req.headers["Authorization"] == "Bearer token"
+    assert resp["id"] == "p"
+
+    httpx_mock.add_response(json={"id": "p"})
+    assert notion.get_page("ws", "token", "p")["id"] == "p"
+
+    httpx_mock.add_response(json={"archived": True})
+    resp = notion.delete_page("ws", "token", "p")
+    assert resp["archived"] is True


### PR DESCRIPTION
## Summary
- expand ClickUp integration to full CRUD with webhook handling
- expand Notion integration similarly
- expose new routers in `main.py`
- add pytest-httpx tests
- include pytest-httpx in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871bb760be08323b7b5081330773ba4