### PR TITLE
Add security middleware and tests

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,8 @@ Continuous integration runs linting, type checks and tests with coverage to ensu
    export BASIC_AUTH_USERS='{"admin": "secret"}'
    export ADMIN_USERS=admin
    ```
-   Obtain a token via `/auth/token` and use it as `Bearer <token>` for requests.
+   Call `/auth/token` to set login cookies and store the returned `csrf_token`.
+   Include that token as `X-CSRF-Token` for subsequent POST requests.
 
 3. Launch the server:
    ```bash

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,3 @@
+# Threat Model
+
+The API exposes authenticated task execution and data management endpoints. Threats include brute force login, session hijacking and CSRF abuse. Rate limiting with SlowAPI caps requests per IP at 100 per minute to deter brute force attempts. OAuth2 access tokens expire after 15 minutes and refresh tokens rotate via `/auth/refresh`, both stored in `HttpOnly` cookies. CSRF protection uses a double‑submit token from `fastapi-csrf-protect` which is set at login and must be sent in the `X-CSRF-Token` header for state-changing requests. These controls minimize the impact of stolen cookies and cross-site attacks while retaining stateless JWT auth.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ redis
 loguru
 prometheus_client
 pytest-httpx
+slowapi
+fastapi-csrf-protect

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,53 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("VERCEL_TOKEN", "test")
+os.environ.setdefault("FERNET_SECRET", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
+os.environ.setdefault("SUPABASE_URL", "http://example.com")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+os.environ.setdefault("TANA_API_KEY", "test")
+os.environ.setdefault("STRIPE_SECRET_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+
+import main as main_module
+importlib.reload(main_module)
+client = TestClient(main_module.app)
+
+
+def test_csrf_and_refresh_flow():
+    os.environ["BASIC_AUTH_USERS"] = '{"user":"pass"}'
+    os.environ["ADMIN_USERS"] = "user"
+    importlib.reload(main_module)
+    c = TestClient(main_module.app)
+    resp = c.post(
+        "/auth/token",
+        data={"username": "user", "password": "pass"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 200
+    csrf_token = resp.json()["csrf_token"]
+    cookies = resp.cookies
+    assert "access_token" in cookies
+    assert "refresh_token" in cookies
+
+    resp2 = c.post("/protected-test", headers={"X-CSRF-Token": csrf_token})
+    assert resp2.status_code == 200
+
+    refresh_cookie = {"refresh_token": cookies.get("refresh_token")}
+    resp3 = c.post("/auth/refresh", cookies=refresh_cookie)
+    assert resp3.status_code == 200
+    assert "csrf_token" in resp3.json()
+    os.environ.pop("BASIC_AUTH_USERS")
+    os.environ.pop("ADMIN_USERS")
+    importlib.reload(main_module)
+
+
+def test_rate_limit():
+    for _ in range(100):
+        r = client.get("/health")
+        assert r.status_code == 200
+    r = client.get("/health")
+    assert r.status_code == 429
+


### PR DESCRIPTION
## Summary
- rate limit API with slowapi
- implement CSRF double-submit flow with fastapi-csrf-protect
- issue short-lived JWT cookies and refresh endpoint
- document the threat model and update README
- add unit tests for auth and rate limits

## Testing
- `ruff check main.py tests/test_security.py` *(fails: E402, F401 etc)*
- `black --check main.py tests/test_security.py` *(fails: would reformat)*
- `mypy .` *(fails: 2 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c6f39bd0832383cd945b6318478b