### PR TITLE
Unify JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Continuous integration runs linting, type checks and tests with coverage to ensu
    ```
    Fill in the required API keys inside `.env`.
 
-2. (Optional) Enable JWT auth by defining users:
+2. Enable JWT auth by defining users:
    ```bash
-   export BASIC_AUTH_USERS='{"admin": "secret"}'
+   export AUTH_USERS='{"admin": "secret"}'
    export ADMIN_USERS=admin
    ```
-   Obtain a token via `/auth/token` and use it as `Bearer <token>` for requests.
+   Obtain a token via `/auth/token` and include `Authorization: Bearer <token>` on requests.
 
 3. Launch the server:
    ```bash
@@ -163,7 +163,7 @@ The same snippet works in Tana, Google Sites or any platform that allows iframes
 ### Customization
 
 - API endpoint base URL is configured with `NEXT_PUBLIC_API_BASE`.
-- Set `NEXT_PUBLIC_AUTH_HEADER` if your FastAPI server requires HTTP Basic or JWT auth (e.g. `"Basic dXNlcjpwYXNz"` or `"Bearer <token>").
+- JWT tokens are read from `localStorage.token` when available. You can set `NEXT_PUBLIC_AUTH_HEADER` to force a static header value.
 - Optional `MAKE_WEBHOOK_URL` is used by the contact form to forward submissions.
 - Branding and styling can be tweaked in `dashboard_ui/styles` and React components.
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
     ESCALATION_CHECK_INTERVAL: int = 1800
     CLAUDE_LOG_FOLDER_ID: str | None = None
 
-    BASIC_AUTH_USERS: str | None = None
+    AUTH_USERS: str | None = None
     ADMIN_USERS: str | None = None
     JWT_SECRET: str = "change-me"
     JWT_ALGORITHM: str = "HS256"

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,12 @@ Continuous integration runs linting, type checks and tests with coverage to ensu
    ```
    Fill in the required API keys inside `.env`.
 
-2. (Optional) Enable JWT auth by defining users:
+2. Enable JWT auth by defining users:
    ```bash
-   export BASIC_AUTH_USERS='{"admin": "secret"}'
+   export AUTH_USERS='{"admin": "secret"}'
    export ADMIN_USERS=admin
    ```
-   Call `/auth/token` to set login cookies and store the returned `csrf_token`.
-   Include that token as `X-CSRF-Token` for subsequent POST requests.
+   Obtain tokens via `/auth/token` and include `Authorization: Bearer <token>` on requests.
 
 3. Launch the server:
    ```bash
@@ -159,10 +158,10 @@ Include the dashboard in another site using:
 ```
 The same snippet works in Tana, Google Sites or any platform that allows iframes.
 
-### Customization
+-### Customization
 
 - API endpoint base URL is configured with `NEXT_PUBLIC_API_BASE`.
-- Set `NEXT_PUBLIC_AUTH_HEADER` if your FastAPI server requires HTTP Basic or JWT auth (e.g. `"Basic dXNlcjpwYXNz"` or `"Bearer <token>").
+- JWT tokens are loaded from `localStorage.token` if present. Optionally set `NEXT_PUBLIC_AUTH_HEADER` to force a static header value.
 - Optional `MAKE_WEBHOOK_URL` is used by the contact form to forward submissions.
 - Branding and styling can be tweaked in `dashboard_ui/styles` and React components.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ npm run dev
 Set environment variables in `.env.local` or your hosting platform:
 
 - `NEXT_PUBLIC_API_BASE` – base URL of the FastAPI server (default '')
-- `NEXT_PUBLIC_AUTH_HEADER` – optional `Authorization` header value for HTTP Basic or JWT
+- `NEXT_PUBLIC_AUTH_HEADER` – optional static `Authorization` header. JWT tokens will otherwise be read from `localStorage.token`.
 
 ## Build & Export
 

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -1,26 +1,34 @@
 import { API_BASE } from './config';
 
+function authHeader() {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) return { Authorization: `Bearer ${token}` };
+  }
+  return {};
+}
+
 export async function postMemoryQuery(query: string) {
   const res = await fetch(`${API_BASE}/memory/query`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify({ query }),
   });
   return res.json();
 }
 
 export async function syncClaudeLogs() {
-  return fetch(`${API_BASE}/sync-claude-logs`, { method: 'POST' }).then(r => r.json());
+  return fetch(`${API_BASE}/sync-claude-logs`, { method: 'POST', headers: authHeader() }).then(r => r.json());
 }
 
 export async function fetchDocuments() {
-  return fetch(`${API_BASE}/documents`).then(r => r.json());
+  return fetch(`${API_BASE}/documents`, { headers: authHeader() }).then(r => r.json());
 }
 
 export async function updateDocument(id: string, content: string) {
   return fetch(`${API_BASE}/memory/update`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify({ document_id: id, content }),
   }).then(r => r.json());
 }
@@ -33,23 +41,23 @@ export async function writeMemory(entry: {
 }) {
   return fetch(`${API_BASE}/memory/write`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(entry),
   }).then(r => r.json());
 }
 
 export async function fetchProductDocs() {
-  return fetch(`${API_BASE}/memory/query?tags=product&limit=50`).then(r => r.json());
+  return fetch(`${API_BASE}/memory/query?tags=product&limit=50`, { headers: authHeader() }).then(r => r.json());
 }
 
 export async function fetchOpsMetrics() {
-  return fetch(`${API_BASE}/dashboard/ops`).then(r => r.json());
+  return fetch(`${API_BASE}/dashboard/ops`, { headers: authHeader() }).then(r => r.json());
 }
 
 export async function fetchRecentPosts() {
-  return fetch(`${API_BASE}/memory/search?limit=5`).then(r => r.json());
+  return fetch(`${API_BASE}/memory/search?limit=5`, { headers: authHeader() }).then(r => r.json());
 }
 
 export async function fetchRecentTasks() {
-  return fetch(`${API_BASE}/dashboard/tasks`).then(r => r.json());
+  return fetch(`${API_BASE}/dashboard/tasks`, { headers: authHeader() }).then(r => r.json());
 }

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -9,7 +9,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("STRIPE_SECRET_KEY", "test")
 os.environ.setdefault("TANA_API_KEY", "test")
 os.environ.setdefault("VERCEL_TOKEN", "test")
-os.environ.pop("BASIC_AUTH_USERS", None)
+os.environ["AUTH_USERS"] = '{"user":"pass"}'
 os.environ.pop("ADMIN_USERS", None)
 import main as main_module
 
@@ -17,30 +17,39 @@ importlib.reload(main_module)
 client = TestClient(main_module.app)
 
 
-def test_memory_write_and_query():
-    os.environ.pop("BASIC_AUTH_USERS", None)
-    os.environ.pop("ADMIN_USERS", None)
+def _auth_client():
     importlib.reload(main_module)
     c = TestClient(main_module.app)
+    token_resp = c.post(
+        "/auth/token",
+        data={"username": "user", "password": "pass"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert token_resp.status_code == 200
+    token = token_resp.json()["access_token"]
+    return TestClient(main_module.app), {"Authorization": f"Bearer {token}"}
+
+
+def test_memory_write_and_query():
+    client, headers = _auth_client()
     payload = {
         "project_id": "test_proj",
         "title": "Test Doc",
         "content": "hello world",
         "author_id": "tester",
     }
-    resp = c.post("/memory/write", json=payload)
+    resp = client.post("/memory/write", json=payload, headers=headers)
     assert resp.status_code == 200
     doc_id = resp.json()["document_id"]
 
-    q = c.post("/memory/query", json={"query": "hello"})
+    q = client.post("/memory/query", json={"query": "hello"}, headers=headers)
     assert q.status_code == 200
     assert q.json()["results"]
 
 
 def test_gemini_sync_route():
-    os.environ.pop("BASIC_AUTH_USERS", None)
-    os.environ.pop("ADMIN_USERS", None)
-    importlib.reload(main_module)
-    c = TestClient(main_module.app)
-    resp = c.post("/memory/gemini-sync", json={"values": ["a", "b"]})
+    client, headers = _auth_client()
+    resp = client.post(
+        "/memory/gemini-sync", json={"values": ["a", "b"]}, headers=headers
+    )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- switch auth config to `AUTH_USERS`
- require JWT for every endpoint
- drop BasicAuth/agent-key modes from chat API
- show how to login in docs and README
- have frontend store JWT in localStorage

## Testing
- `black core/settings.py main.py chat_task_api.py tests/test_basic.py tests/test_celery.py tests/test_chat_task_api.py tests/test_memory_api.py tests/test_security.py`
- `pytest -q` *(fails: assert 200 == 401)*

------
https://chatgpt.com/codex/tasks/task_e_6872961296f08323a8ed83b02adcf921