### PR TITLE
Add streaming support for blog and agent tasks

### DIFF
--- a/codex/tasks/ai_coauthored_composer.py
+++ b/codex/tasks/ai_coauthored_composer.py
@@ -7,7 +7,10 @@ import logging
 import os
 from typing import Any, Dict
 
+from typing import AsyncGenerator
+
 from codex.memory import memory_store
+from utils.ai_router import get_ai_model, stream_completion
 from . import claude_prompt, gemini_prompt
 
 TASK_ID = "ai_coauthored_composer"
@@ -25,13 +28,23 @@ def run(context: Dict[str, Any]) -> Dict[str, Any]:
     if not intent:
         return {"error": "missing_intent"}
 
-    step1 = claude_prompt.run({"prompt": f"Draft a task skeleton for: {intent}. Respond in JSON."})
+    step1 = claude_prompt.run(
+        {"prompt": f"Draft a task skeleton for: {intent}. Respond in JSON."}
+    )
     skeleton = step1.get("completion", "")
 
-    step2 = gemini_prompt.run({"prompt": f"Expand this skeleton with technical details. Respond in JSON.\n{skeleton}"})
+    step2 = gemini_prompt.run(
+        {
+            "prompt": f"Expand this skeleton with technical details. Respond in JSON.\n{skeleton}"
+        }
+    )
     expanded = step2.get("completion", "")
 
-    final = claude_prompt.run({"prompt": f"Finalize this plan for {intent}. Ensure logic is sound and goals clear. Respond in JSON.\n{expanded}"})
+    final = claude_prompt.run(
+        {
+            "prompt": f"Finalize this plan for {intent}. Ensure logic is sound and goals clear. Respond in JSON.\n{expanded}"
+        }
+    )
     final_raw = final.get("completion", "")
     executed_by = final.get("executed_by", "claude")
 
@@ -53,3 +66,51 @@ def run(context: Dict[str, Any]) -> Dict[str, Any]:
     )
 
     return {"plan": plan, "metadata": metadata, "executed_by": executed_by}
+
+
+async def stream(context: Dict[str, Any]) -> AsyncGenerator[str, None]:
+    """Yield tokens while composing a multi-step plan."""
+    if os.getenv("AI_COAUTHOR_MODE") != "enabled":
+        yield "[error] disabled"
+        return
+
+    intent = context.get("intent")
+    if not intent:
+        yield "[error] missing_intent"
+        return
+
+    step1_prompt = f"Draft a task skeleton for: {intent}. Respond in JSON."
+    skeleton = ""
+    async for token in stream_completion(step1_prompt, get_ai_model(TASK_ID)):
+        skeleton += token
+        yield token
+
+    step2 = gemini_prompt.run(
+        {
+            "prompt": f"Expand this skeleton with technical details. Respond in JSON.\n{skeleton}"
+        }
+    )
+    expanded = step2.get("completion", "")
+
+    final_prompt = f"Finalize this plan for {intent}. Ensure logic is sound and goals clear. Respond in JSON.\n{expanded}"
+    final_output = ""
+    async for token in stream_completion(final_prompt, get_ai_model(TASK_ID)):
+        final_output += token
+        yield token
+
+    try:
+        plan = json.loads(final_output)
+    except Exception:
+        plan = {"tasks": []}
+
+    metadata = {"authors": ["claude", "gemini"], "version": "1.0"}
+    memory_store.save_memory(
+        {
+            "task": TASK_ID,
+            "input": intent,
+            "output": plan,
+            "metadata": metadata,
+            "tags": ["coauthored"],
+        },
+        origin={"model": get_ai_model(TASK_ID)},
+    )

--- a/codex/tasks/claude_blog_from_memory.py
+++ b/codex/tasks/claude_blog_from_memory.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
+from typing import AsyncGenerator
+
 from codex.memory import memory_store
 from utils.template_loader import render_template
+from utils.ai_router import get_ai_model, stream_completion
 from . import claude_prompt, tana_create
 
 TASK_ID = "claude_blog_from_memory"
@@ -42,3 +45,36 @@ def run(context: Dict[str, Any]) -> Dict[str, Any]:
         except Exception:  # noqa: BLE001
             logger.exception("Failed to send blog to Tana")
     return {"blog": blog, "executed_by": executed_by}
+
+
+async def stream(context: Dict[str, Any]) -> AsyncGenerator[str, None]:
+    """Yield blog tokens using the configured AI model."""
+    records = memory_store.fetch_all(limit=3)
+    if not records:
+        yield "[error] no_memory"
+        return
+    text = "\n\n".join(str(r.get("output") or r) for r in records)
+    title = context.get("title", "AI Update")
+    prompt = render_template("ai_blog_summary", {"title": title, "input": text})
+    model = get_ai_model(TASK_ID)
+
+    blog = ""
+    async for token in stream_completion(prompt, model):
+        blog += token
+        yield token
+
+    memory_store.save_memory(
+        {
+            "task": TASK_ID,
+            "input": text,
+            "output": blog,
+            "user": context.get("user", "default"),
+            "tags": ["blog"],
+        },
+        origin={"model": model},
+    )
+    if context.get("tana"):
+        try:
+            tana_create.run({"content": blog, "metadata": {"tags": ["blog"]}})
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to send blog to Tana")

--- a/utils/ai_router.py
+++ b/utils/ai_router.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import AsyncGenerator
+
 from core.settings import Settings
+from claude_utils import run_claude, stream_claude
+from gpt_utils import run_gpt, stream_gpt
 
 settings = Settings()
 
@@ -22,3 +26,20 @@ def get_ai_model(task: str | None = None) -> str:
     if any(k in name for k in ["code", "inspect", "data", "query", "rag"]):
         return "gemini"
     return "claude"
+
+
+async def stream_completion(prompt: str, model: str) -> AsyncGenerator[str, None]:
+    """Stream completion tokens for the selected model."""
+    if model == "gemini":
+        async for token in stream_gpt(prompt):
+            yield token
+    else:
+        async for token in stream_claude(prompt):
+            yield token
+
+
+async def run_completion(prompt: str, model: str) -> str:
+    """Return full completion string for the selected model."""
+    if model == "gemini":
+        return await run_gpt(prompt)
+    return await run_claude(prompt)


### PR DESCRIPTION
## Summary
- add `stream_completion` helper
- allow streaming in blog and coauthor tasks
- implement `stream_task` generator
- extend `/task/run` for streaming responses
- support token expiration on restart

## Testing
- `pytest -q` *(fails: token mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6872a6b5cee08323b3ef5c785c27d127