### PR TITLE
Add ClickUp task adapter

### DIFF
--- a/codex/integrations/clickup_adapter.py
+++ b/codex/integrations/clickup_adapter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Simplified ClickUp adapter used by tasks."""
+
+from typing import Any, Dict, List
+import logging
+import os
+
+from . import clickup
+
+logger = logging.getLogger(__name__)
+
+
+def search_clickup_tasks(query: str) -> List[Dict[str, Any]]:
+    """Search ClickUp for tasks matching ``query``."""
+    token = os.getenv("CLICKUP_API_TOKEN")
+    if not token:
+        logger.warning("No CLICKUP_API_TOKEN configured")
+        return []
+    try:
+        return clickup.search_tasks("", token, query)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("ClickUp search failed: %s", exc)
+        return []
+
+
+def create_clickup_task(task_data: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Create a ClickUp task from ``task_data``.
+
+    Expected keys are ``title``, ``description`` and ``list_id``. An optional
+    ``token`` overrides the default ``CLICKUP_API_TOKEN``.
+    """
+    list_id = task_data.get("list_id")
+    if not list_id:
+        logger.error("Missing list_id for ClickUp task creation")
+        return None
+    token = task_data.get("token") or os.getenv("CLICKUP_API_TOKEN")
+    if not token:
+        logger.error("No CLICKUP_API_TOKEN configured")
+        return None
+    title = task_data.get("title", "Untitled")
+    description = task_data.get("description", "")
+    try:
+        return clickup.create_task("", token, list_id, title, description)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("ClickUp create failed: %s", exc)
+        return {"error": str(exc)}
+
+
+def update_clickup_task(task_id: str, fields: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Update a ClickUp task with ``fields``."""
+    token = fields.pop("token", None) or os.getenv("CLICKUP_API_TOKEN")
+    if not token:
+        logger.error("No CLICKUP_API_TOKEN configured")
+        return None
+    try:
+        return clickup.update_task("", token, task_id, fields)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("ClickUp update failed: %s", exc)
+        return {"error": str(exc)}

--- a/docs/master_guide.md
+++ b/docs/master_guide.md
@@ -153,7 +153,7 @@ GitHub
  Notion: adapter functions search_notion_pages, get_page_snippet. 
 Notion Developers
 
- ClickUp: create_task, search_tasks; secret via vault. 
+ ClickUp: create_clickup_task, search_clickup_tasks; secret via vault.
 ClickUp Developer Docs
 
  Slack Inbound: /webhook/slack/command, verify signing secret. 
@@ -254,7 +254,7 @@ Notion Developers
  & Python tutorial 
 pynotion.com
 
-ClickUp task endpoints 
+ClickUp adapter & task endpoints
 ClickUp Developer Docs
 ClickUp Developer Docs
 


### PR DESCRIPTION
## Summary
- add `clickup_adapter` with basic search/create/update helpers
- hook ClickUp sync into the task runner
- document new ClickUp adapter functions

## Testing
- `pytest tests/test_basic.py tests/test_chat_task_api.py tests/test_integrations.py tests/test_memory_api.py tests/test_security.py tests/test_celery.py -q` *(fails: 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872bf852d2483239b4af47fae71cb99