### PR TITLE
Add Slack webhook handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ required variables raise an error. Supabase credentials are required in
 production for persistent memory storage. Set `SLACK_WEBHOOK_URL` to a Slack
 incoming webhook to get notified when tasks succeed or fail.
 
+### Slack commands
+Register a `/brainops` slash command in your Slack workspace pointing to
+`/webhook/slack/command`. Set `SLACK_SIGNING_SECRET` so requests can be
+verified. Commands include:
+
+* `approve <id>` – run and mark an inbox task approved
+* `reject <id>` – mark a task rejected
+* `status <id>` – view the stored status
+* `query <text>` – search recent memory for information
+
+Slack Events can be sent to `/webhook/slack/event` if you want to store
+messages from channels.
+
 ### Database migrations
 Before running the server in production, apply the Alembic migrations to ensure
 the database schema and extensions are up to date:

--- a/docs/master_guide.md
+++ b/docs/master_guide.md
@@ -156,7 +156,8 @@ Notion Developers
  ClickUp: create_clickup_task, search_clickup_tasks; secret via vault.
 ClickUp Developer Docs
 
- Slack Inbound: /webhook/slack/command, verify signing secret. 
+ Slack Inbound: /webhook/slack/command, verify signing secret. Events can be
+ sent to /webhook/slack/event to capture channel messages.
 Slack API
 
  Stripe: /webhook/stripe, verify signature, enqueue sync_sale. 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,71 @@
+import importlib
+import os
+import hmac
+import hashlib
+import time
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SUPABASE_URL", "http://example.com")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("STRIPE_SECRET_KEY", "test")
+os.environ.setdefault("TANA_API_KEY", "test")
+os.environ.setdefault("VERCEL_TOKEN", "test")
+os.environ.setdefault("FERNET_SECRET", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
+
+os.environ["SLACK_SIGNING_SECRET"] = "secret"
+
+import main as main_module
+
+importlib.reload(main_module)
+client = TestClient(main_module.app)
+
+from codex.memory import agent_inbox
+
+
+def _sign(body: str, ts: str) -> str:
+    digest = hmac.new(
+        os.environ["SLACK_SIGNING_SECRET"].encode(),
+        f"v0:{ts}:{body}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"v0={digest}"
+
+
+def test_slack_command_flow():
+    item = agent_inbox.add_to_inbox("claude_prompt", {"prompt": "hi"}, "test")
+    text = f"approve {item['task_id']}"
+    body = f"text={text.replace(' ', '+')}"
+    ts = str(int(time.time()))
+    sig = _sign(body, ts)
+    resp = client.post(
+        "/webhook/slack/command",
+        data={"text": text},
+        headers={"X-Slack-Signature": sig, "X-Slack-Request-Timestamp": ts},
+    )
+    assert resp.status_code == 200
+    assert "approved" in resp.json()["text"]
+
+    text2 = f"status {item['task_id']}"
+    body2 = f"text={text2.replace(' ', '+')}"
+    ts2 = str(int(time.time()))
+    sig2 = _sign(body2, ts2)
+    resp2 = client.post(
+        "/webhook/slack/command",
+        data={"text": text2},
+        headers={"X-Slack-Signature": sig2, "X-Slack-Request-Timestamp": ts2},
+    )
+    assert resp2.status_code == 200
+    assert item["task_id"] in resp2.json()["text"]
+
+    text3 = "query nothing"
+    body3 = f"text={text3.replace(' ', '+')}"
+    ts3 = str(int(time.time()))
+    sig3 = _sign(body3, ts3)
+    resp3 = client.post(
+        "/webhook/slack/command",
+        data={"text": text3},
+        headers={"X-Slack-Signature": sig3, "X-Slack-Request-Timestamp": ts3},
+    )
+    assert resp3.status_code == 200
+    assert "No results" in resp3.json()["text"]


### PR DESCRIPTION
## Summary
- verify Slack signatures with timestamp
- extend `/webhook/slack/command` with `status` and `query` actions
- store Slack events via new `/webhook/slack/event` endpoint
- document Slack slash command usage
- add regression test for Slack commands

## Testing
- `ruff check .` *(fails: unrecognized rules)*
- `black --check .` *(fails: would reformat 48 files)*
- `mypy .` *(fails: 2 errors)*
- `pytest -q` *(fails: 17 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc3bf58083239ef8701eb3bbc140