### PR TITLE
Emergency repair – Supabase, import, Docker, settings, health endpoint

### DIFF
--- a/apps/backend/memory/backend_memory_knowledge.py
+++ b/apps/backend/memory/backend_memory_knowledge.py
@@ -16,7 +16,7 @@ from .models import (
     DocumentChunk, KnowledgeEntry, KnowledgeCategory,
     MemoryType, MemoryRecord
 )
-from .supabase_client import get_supabase_client
+from .supabase_client import get_supabase_client_sync
 from .vector_utils import generate_embedding, chunk_text_with_overlap
 from ..core.logging import get_logger
 
@@ -30,7 +30,7 @@ class KnowledgeManager:
     """
     
     def __init__(self):
-        self.supabase = get_supabase_client()
+        self.supabase = get_supabase_client_sync()
         
         # Chunking parameters optimized for different content types
         self.chunk_configs = {

--- a/apps/backend/memory/backend_memory_store.py
+++ b/apps/backend/memory/backend_memory_store.py
@@ -20,7 +20,7 @@ from .backend_memory_models import (
     EstimateRecord,
     RetrievalSession,
 )
-from .supabase_client import get_supabase_client
+from .supabase_client import get_supabase_client_sync
 from .backend_memory_vector_utils import generate_embedding, calculate_similarity
 from ..core.logging import get_logger
 from .models import (
@@ -41,7 +41,8 @@ class MemoryStore:
     """
     
     def __init__(self):
-        self.supabase = get_supabase_client()
+        # Initialize Supabase client synchronously for use in async methods
+        self.supabase = get_supabase_client_sync()
         self._cache = {}  # Simple in-memory cache for frequent queries
         
     async def store_memory(

--- a/apps/backend/memory/knowledge.py
+++ b/apps/backend/memory/knowledge.py
@@ -20,7 +20,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from apps.backend.core.settings import settings
 from apps.backend.core.logging import get_logger
 from .backend_memory_vector_utils import generate_embeddings, cosine_similarity
-from .supabase_client import get_supabase_client
+from .supabase_client import get_supabase_client_sync
 
 
 logger = get_logger(__name__)
@@ -36,7 +36,7 @@ class KnowledgeManager:
     """
     
     def __init__(self):
-        self.supabase = get_supabase_client()
+        self.supabase = get_supabase_client_sync()
         self.encoding = tiktoken.encoding_for_model(settings.EMBEDDING_MODEL) if tiktoken else None
         
         # Configure text splitter for optimal chunk sizes

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ requests==2.31.0
 python-dotenv==1.0.0
 pyyaml==6.0.1
 orjson==3.9.10  # Fast JSON parsing
-httpx==0.25.2
+httpx==0.27.0
 tenacity==8.2.3  # Retry logic
 
 # Monitoring & Logging
@@ -72,4 +72,4 @@ pre-commit==3.6.0
 # Documentation
 mkdocs==1.5.3
 mkdocs-material==9.5.4
-pydoc-markdown==4.8.2
+pydoc-markdown==4.8.2PyGithub==1.59.1


### PR DESCRIPTION
## Summary
- fix Supabase async client creation using `ClientOptions`
- ensure memory modules use synchronous client initializer
- bump httpx to 0.27.0 and add PyGithub for tests
- tweak knowledge and memory store modules

## Testing
- `pip install PyGithub==1.59.1`
- `pytest -q`
- `uvicorn apps.backend.main:app --port 8000`
- `curl -s http://127.0.0.1:8000/health`

------
https://chatgpt.com/codex/tasks/task_e_6878293ea9388323a62b86f5ec514076