### PR TITLE
Fix supabase lru_cache import and Docker port binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${PORT}/health || exit 1
 
 # Expose port
-EXPOSE 8000
+EXPOSE $PORT
 
 # Start the FastAPI application with Uvicorn
 # Using apps.backend.main:app because main.py is in apps/backend/
-CMD ["uvicorn", "apps.backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+CMD ["uvicorn", "apps.backend.main:app", "--host", "0.0.0.0", "--port", "$PORT", "--workers", "2"]

--- a/apps/backend/memory/backend_memory_supabase_client.py
+++ b/apps/backend/memory/backend_memory_supabase_client.py
@@ -8,6 +8,7 @@ connection pooling, and database schema management for BrainOps.
 from typing import Optional, Dict, Any
 import os
 from datetime import datetime, timedelta
+from functools import lru_cache
 from supabase import create_client, Client
 from postgrest import AsyncPostgrestClient
 import asyncio


### PR DESCRIPTION
## Summary
- fix import error by bringing in `lru_cache`
- ensure Docker container uses `$PORT`

## Testing
- `pip install -r requirements.txt`
- `uvicorn apps.backend.main:app --host 0.0.0.0 --port $PORT` *(fails: Invalid API key)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'github')*

------
https://chatgpt.com/codex/tasks/task_e_687883faac908323852c9a887ff16bfa