### PR TITLE
Remove awaits from Supabase sync client

### DIFF
--- a/apps/backend/memory/backend_memory_knowledge.py
+++ b/apps/backend/memory/backend_memory_knowledge.py
@@ -107,7 +107,7 @@ class KnowledgeManager:
                 "created_at": datetime.utcnow().isoformat()
             }
             
-            await self.supabase.table('documents').insert(doc_metadata).execute()
+            self.supabase.table('documents').insert(doc_metadata).execute()
             
             # Process and store chunks
             chunks = await self._create_document_chunks(
@@ -171,7 +171,7 @@ class KnowledgeManager:
             }
             
             # Execute vector search
-            result = await self.supabase.rpc(
+            result = self.supabase.rpc(
                 'search_document_chunks',
                 search_params
             ).execute()
@@ -279,7 +279,7 @@ class KnowledgeManager:
             
             # Increment version if content changed
             if "body" in updates:
-                current = await self.supabase.table('knowledge_entries')\
+                current = self.supabase.table('knowledge_entries')\
                     .select('version')\
                     .eq('id', str(entry_id))\
                     .single()\
@@ -291,7 +291,7 @@ class KnowledgeManager:
                     updates['version'] = '.'.join(version_parts)
             
             # Update the entry
-            result = await self.supabase.table('knowledge_entries')\
+            result = self.supabase.table('knowledge_entries')\
                 .update(updates)\
                 .eq('id', str(entry_id))\
                 .execute()
@@ -381,7 +381,7 @@ class KnowledgeManager:
                 for chunk in chunk_objects
             ]
             
-            await self.supabase.table('document_chunks').insert(chunk_dicts).execute()
+            self.supabase.table('document_chunks').insert(chunk_dicts).execute()
         
         return chunk_objects
     
@@ -465,7 +465,7 @@ class KnowledgeManager:
         """
         
         try:
-            result = await self.supabase.table('documents')\
+            result = self.supabase.table('documents')\
                 .select('id')\
                 .eq('content_hash', content_hash)\
                 .single()\
@@ -503,7 +503,7 @@ class KnowledgeManager:
         )
         
         try:
-            await self.supabase.table('knowledge_entries').insert({
+            self.supabase.table('knowledge_entries').insert({
                 **entry.dict(exclude={'id'}),
                 "id": str(entry.id),
                 "document_id": str(document_id)

--- a/apps/backend/memory/backend_memory_supabase_client.py
+++ b/apps/backend/memory/backend_memory_supabase_client.py
@@ -67,7 +67,7 @@ async def get_supabase_client() -> Client:
             logger.info("Supabase client initialized successfully")
             
             # Verify pgvector extension is enabled
-            await verify_pgvector_extension(_supabase_client)
+            verify_pgvector_extension(_supabase_client)
             
             return _supabase_client
             
@@ -76,14 +76,14 @@ async def get_supabase_client() -> Client:
             raise
 
 
-async def verify_pgvector_extension(client: Client):
+def verify_pgvector_extension(client: Client):
     """
     Verify that pgvector extension is installed and configured.
     Creates necessary indexes if they don't exist.
     """
     try:
         # Check if pgvector extension exists
-        result = await client.rpc('check_pgvector_extension', {}).execute()
+        result = client.rpc('check_pgvector_extension', {}).execute()
         
         if not result.data:
             logger.warning("pgvector extension not found, attempting to create...")
@@ -150,7 +150,7 @@ class SupabaseQueryBuilder:
         """
         
         # Use Supabase RPC function for vector search
-        result = await self.client.rpc(
+        result = self.client.rpc(
             f'search_{table_name}',
             {
                 'query_embedding': embedding,
@@ -441,13 +441,13 @@ async def cleanup_old_records(days: int = 90):
     
     try:
         # Clean up old retrieval sessions
-        await client.table('retrieval_sessions')\
+        client.table('retrieval_sessions')\
             .delete()\
             .lt('created_at', cutoff_date.isoformat())\
             .execute()
         
         # Clean up orphaned memory records
-        await client.rpc('cleanup_orphaned_records', {}).execute()
+        client.rpc('cleanup_orphaned_records', {}).execute()
         
         logger.info(f"Cleaned up records older than {days} days")
         
@@ -468,7 +468,7 @@ async def check_connection_health() -> bool:
         client = await get_supabase_client()
         
         # Simple query to test connection
-        result = await client.table('memory_records')\
+        result = client.table('memory_records')\
             .select('id')\
             .limit(1)\
             .execute()


### PR DESCRIPTION
## Summary
- remove `await` from Supabase `.execute()` calls
- keep async structure otherwise

## Testing
- `pip install PyGithub`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795f3b165883238dd96ea47db282e9